### PR TITLE
support for multiple working directories

### DIFF
--- a/exod/main.go
+++ b/exod/main.go
@@ -3,6 +3,7 @@ package exod
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/deref/exo/components/log"
 	"github.com/deref/exo/gui"
@@ -16,6 +17,10 @@ func Main() {
 	cfg := &kernel.Config{
 		VarDir:     paths.VarDir,
 		MuxPattern: "/",
+	}
+
+	if err := os.Chdir("/"); err != nil {
+		cmdutil.Fatalf("chdir failed: %w", err)
 	}
 
 	ctx := kernel.NewContext(context.Background(), cfg)

--- a/kernel/api/kernel.go
+++ b/kernel/api/kernel.go
@@ -1,3 +1,67 @@
+// Generated file. DO NOT EDIT.
+
 package api
 
-type Kernel = Project // XXX
+import (
+	"context"
+	"net/http"
+
+	josh "github.com/deref/exo/josh/server"
+)
+
+type Kernel interface {
+	CreateWorkspace(context.Context, *CreateWorkspaceInput) (*CreateWorkspaceOutput, error)
+	ForgetWorkspace(context.Context, *ForgetWorkspaceInput) (*ForgetWorkspaceOutput, error)
+	DescribeWorkspaces(context.Context, *DescribeWorkspacesInput) (*DescribeWorkspacesOutput, error)
+	FindWorkspace(context.Context, *FindWorkspaceInput) (*FindWorkspaceOutput, error)
+}
+
+type CreateWorkspaceInput struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type CreateWorkspaceOutput struct {
+}
+
+type ForgetWorkspaceInput struct {
+	Ref string `json:"ref"`
+}
+
+type ForgetWorkspaceOutput struct {
+}
+
+type DescribeWorkspacesInput struct {
+}
+
+type DescribeWorkspacesOutput struct {
+	Workspaces []WorkspaceDescription `json:"workspaces"`
+}
+
+type FindWorkspaceInput struct {
+	Path string `json:"path"`
+}
+
+type FindWorkspaceOutput struct {
+	ID *string `json:"id"`
+}
+
+func NewKernelMux(prefix string, iface Kernel) *http.ServeMux {
+	b := josh.NewMuxBuilder(prefix)
+	BuildKernelMux(b, iface)
+	return b.Mux()
+}
+
+func BuildKernelMux(b *josh.MuxBuilder, iface Kernel) {
+	b.AddMethod("create-workspace", iface.CreateWorkspace)
+	b.AddMethod("forget-workspace", iface.ForgetWorkspace)
+	b.AddMethod("describe-workspaces", iface.DescribeWorkspaces)
+	b.AddMethod("find-workspace", iface.FindWorkspace)
+}
+
+type WorkspaceDescription struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Root    string `json:"root"`
+	Project string `json:"project"`
+}

--- a/kernel/api/kernel.josh.hcl
+++ b/kernel/api/kernel.josh.hcl
@@ -1,0 +1,29 @@
+interface "kernel" {
+  
+  method "create-workspace" {
+    input "name" "string" {}
+    input "path" "string" {}
+  }
+  
+  method "forget-workspace" {
+    input "ref" "string" {}
+  }
+  
+  method "describe-workspaces" {
+    output "workspaces" "[]WorkspaceDescription" {}
+  }
+  
+  method "find-workspace" {
+    input "path" "string" {}
+
+    output "id" "*string" {}
+  }
+
+}
+
+struct "workspace-description" {
+  field "id" "string" {}
+  field "name" "string" {}
+  field "root" "string" {}
+  field "project" "string" {}
+}

--- a/kernel/client/kernel.go
+++ b/kernel/client/kernel.go
@@ -1,0 +1,42 @@
+// Generated file. DO NOT EDIT.
+
+package client
+
+import (
+	"context"
+
+	josh "github.com/deref/exo/josh/client"
+	"github.com/deref/exo/kernel/api"
+)
+
+type Kernel struct {
+	client *josh.Client
+}
+
+var _ api.Kernel = (*Kernel)(nil)
+
+func NewKernel(client *josh.Client) *Kernel {
+	return &Kernel{
+		client: client,
+	}
+}
+
+func (c *Kernel) CreateWorkspace(ctx context.Context, input *api.CreateWorkspaceInput) (output *api.CreateWorkspaceOutput, err error) {
+	err = c.client.Invoke(ctx, "create-workspace", input, &output)
+	return
+}
+
+func (c *Kernel) ForgetWorkspace(ctx context.Context, input *api.ForgetWorkspaceInput) (output *api.ForgetWorkspaceOutput, err error) {
+	err = c.client.Invoke(ctx, "forget-workspace", input, &output)
+	return
+}
+
+func (c *Kernel) DescribeWorkspaces(ctx context.Context, input *api.DescribeWorkspacesInput) (output *api.DescribeWorkspacesOutput, err error) {
+	err = c.client.Invoke(ctx, "describe-workspaces", input, &output)
+	return
+}
+
+func (c *Kernel) FindWorkspace(ctx context.Context, input *api.FindWorkspaceInput) (output *api.FindWorkspaceOutput, err error) {
+	err = c.client.Invoke(ctx, "find-workspace", input, &output)
+	return
+}


### PR DESCRIPTION
haven't really started in earnest yet, just opening the PR with the interface file change.

interestingly, this breaks the code statically in all the right places where we need to insert calls to `find-workspace` in the CLI tool.