### PR TITLE
add controller definitions to codegen hcl

### DIFF
--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -35,9 +35,9 @@ func main() {
 			return err
 		}
 
-		unit, err := codegen.ParseFile(path)
+		unit, err := codegen.LoadFile(path)
 		if err != nil {
-			return fmt.Errorf("parsing %q: %w", path, err)
+			return fmt.Errorf("loading %q: %w", path, err)
 		}
 
 		pkg := &codegen.Package{

--- a/components/process/provider.go
+++ b/components/process/provider.go
@@ -16,5 +16,5 @@ type State struct {
 	Pid int `json:"pid"`
 	// TODO: Store resolved program path & full effective environment.
 	// Program string `json:"program"`
-	// Environment string `json:"environment"`
+	// Environment map[string]string `json:"environment"`
 }

--- a/core/api/lifecycle.go
+++ b/core/api/lifecycle.go
@@ -17,8 +17,9 @@ type Lifecycle interface {
 }
 
 type InitializeInput struct {
-	ID   string `json:"id"`
-	Spec string `json:"spec"`
+	ID    string `json:"id"`
+	Spec  string `json:"spec"`
+	State string `json:"state"`
 }
 
 type InitializeOutput struct {
@@ -27,9 +28,9 @@ type InitializeOutput struct {
 
 type UpdateInput struct {
 	ID      string `json:"id"`
-	OldSpec string `json:"oldSpec"`
-	NewSpec string `json:"newSpec"`
+	Spec    string `json:"spec"`
 	State   string `json:"state"`
+	NewSpec string `json:"newSpec"`
 }
 
 type UpdateOutput struct {

--- a/core/api/lifecycle.josh.hcl
+++ b/core/api/lifecycle.josh.hcl
@@ -1,35 +1,14 @@
-interface "lifecycle" {
+controller "lifecycle" {
   
-  method "initialize" {
-    input "id" "string" {}
-    input "spec" "string" {}
-
-    output "state" "string" {}
-  }
+  method "initialize" {}
   
   method "update" {
-    input "id" "string" {}
-    input "old-spec" "string" {}
     input "new-spec" "string" {}
-    input "state" "string" {}
-
-    output "state" "string" {}
   }
   
-  method "refresh" {
-    input "id" "string" {}
-    input "spec" "string" {}
-    input "state" "string" {}
-
-    output "state" "string" {}
-  }
+  method "refresh" {}
   
   method "dispose" {
-    input "id" "string" {}
-    input "spec" "string" {}
-    input "state" "string" {}
-    
-    output "state" "string" {}
     // TODO: output promise for awaiting synchronous deletes.
   }
 

--- a/core/api/process.josh.hcl
+++ b/core/api/process.josh.hcl
@@ -1,14 +1,4 @@
-interface "process" {
-  method "start" {
-    input "id" "string" {}
-    input "spec" "string" {}
-    input "state" "string" {}
-    output "state" "string" {}
-  }
-  method "stop" {
-    input "id" "string" {}
-    input "spec" "string" {}
-    input "state" "string" {}
-    output "state" "string" {}
-  }
+controller "process" {
+  method "start" {}
+  method "stop" {}
 }


### PR DESCRIPTION
Step towards standardizing the wire interfaces for controllers. Not included in this is some sort of automatic marshalling of specs and state in/out, but that requires some more thought. All this does not is automatically add id, spec, and state inputs, as well as a state output to each controller method.