### PR TITLE
Add get version api

### DIFF
--- a/exod/api/kernel.go
+++ b/exod/api/kernel.go
@@ -15,6 +15,8 @@ type Kernel interface {
 	FindWorkspace(context.Context, *FindWorkspaceInput) (*FindWorkspaceOutput, error)
 	// Debug method to test what happens when the service panics.
 	Panic(context.Context, *PanicInput) (*PanicOutput, error)
+	// Retrieves the installed and current version of exo.
+	GetVersion(context.Context, *GetVersionInput) (*GetVersionOutput, error)
 }
 
 type CreateWorkspaceInput struct {
@@ -47,6 +49,15 @@ type PanicInput struct {
 type PanicOutput struct {
 }
 
+type GetVersionInput struct {
+}
+
+type GetVersionOutput struct {
+	Installed string  `json:"installed"`
+	Latest    *string `json:"latest"`
+	Current   bool    `json:"current"`
+}
+
 func BuildKernelMux(b *josh.MuxBuilder, factory func(req *http.Request) Kernel) {
 	b.AddMethod("create-workspace", func(req *http.Request) interface{} {
 		return factory(req).CreateWorkspace
@@ -59,5 +70,8 @@ func BuildKernelMux(b *josh.MuxBuilder, factory func(req *http.Request) Kernel) 
 	})
 	b.AddMethod("panic", func(req *http.Request) interface{} {
 		return factory(req).Panic
+	})
+	b.AddMethod("get-version", func(req *http.Request) interface{} {
+		return factory(req).GetVersion
 	})
 }

--- a/exod/api/kernel.josh.hcl
+++ b/exod/api/kernel.josh.hcl
@@ -22,4 +22,13 @@ interface "kernel" {
     input "message" "string" {}
   }
 
+  method "get-version" {
+    doc = "Retrieves the installed and current version of exo."
+
+    output "installed" "string" {}
+    // Current may be nil if telemetry is disabled.
+    output "latest" "*string" {}
+    output "current" "bool" {}
+  }
+
 }

--- a/exod/client/kernel.go
+++ b/exod/client/kernel.go
@@ -40,3 +40,8 @@ func (c *Kernel) Panic(ctx context.Context, input *api.PanicInput) (output *api.
 	err = c.client.Invoke(ctx, "panic", input, &output)
 	return
 }
+
+func (c *Kernel) GetVersion(ctx context.Context, input *api.GetVersionInput) (output *api.GetVersionOutput, err error) {
+	err = c.client.Invoke(ctx, "get-version", input, &output)
+	return
+}

--- a/exod/server/kernel.go
+++ b/exod/server/kernel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/deref/exo/exod/api"
 	state "github.com/deref/exo/exod/state/api"
 	"github.com/deref/exo/gensym"
+	"github.com/deref/exo/telemetry"
 )
 
 type Kernel struct {
@@ -53,6 +54,26 @@ func (kern *Kernel) FindWorkspace(ctx context.Context, input *api.FindWorkspaceI
 	}
 	return &api.FindWorkspaceOutput{
 		ID: output.ID,
+	}, nil
+}
+
+func (kern *Kernel) GetVersion(ctx context.Context, input *api.GetVersionInput) (*api.GetVersionOutput, error) {
+	installed := telemetry.CurrentVersion()
+	current := true
+	var latest *string
+	if telemetry.CanSelfUpgrade() {
+		latestVersion, err := telemetry.LatestVersion()
+		if err != nil {
+			return nil, err
+		}
+		latest = &latestVersion
+		current = installed >= latestVersion
+	}
+
+	return &api.GetVersionOutput{
+		Installed: installed,
+		Latest:    latest,
+		Current:   current,
 	}, nil
 }
 

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -1,3 +1,4 @@
+import type { GetVersionResponse } from './kernel/types';
 import type { LogsResponse } from './logs/types';
 import type {
   CreateProcessResponse,
@@ -154,6 +155,10 @@ export const api = (() => {
         const { id } = (await invoke('create-workspace', { root })) as any;
         return id;
       },
+
+      async getVersion(): Promise<GetVersionResponse> {
+        return await invoke('get-version', {}) as any;
+      }
     };
   })();
 

--- a/gui/src/lib/kernel/types.ts
+++ b/gui/src/lib/kernel/types.ts
@@ -1,0 +1,5 @@
+export interface GetVersionResponse {
+    installed: string;
+    latest?: string;
+    current: string;
+}

--- a/telemetry/autoinstalled.go
+++ b/telemetry/autoinstalled.go
@@ -13,6 +13,8 @@ import (
 	"github.com/deref/exo/core"
 )
 
+const isManaged = false
+
 func UpgradeSelf() error {
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {

--- a/telemetry/managed.go
+++ b/telemetry/managed.go
@@ -4,6 +4,8 @@ package telemetry
 
 import "fmt"
 
+const isManaged = true
+
 func UpgradeSelf() error {
 	fmt.Println(`This version of exo was installed via a package manager and does not support self-upgrade. Please use your package manager to update.
 

--- a/telemetry/version.go
+++ b/telemetry/version.go
@@ -8,13 +8,18 @@ import (
 	"github.com/deref/exo/core"
 )
 
+// TODO: Find a better place for this and the autoinstalled/managed files to live.s
+func CanSelfUpgrade() bool {
+	return !isManaged
+}
+
 // LatestVersion returns the version of the running exo process.
 func CurrentVersion() string {
 	return core.Version
 }
 
 // LatestVersion returns the latest version fetched from the web.
-// TODO: Cache response.
+// TODO: Cache response!
 func LatestVersion() (string, error) {
 	resp, err := http.Get(core.CheckVersionEndpoint)
 	if err != nil {


### PR DESCRIPTION
This adds a kernel API for getting the installed and latest version. It can be used in the UI to indicate whether an upgrade is needed.