### PR TITLE
`exo run`

### DIFF
--- a/cmd/exo/apply.go
+++ b/cmd/exo/apply.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -65,25 +66,29 @@ overidden explicitly with the --format flag.`,
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 
-		input := &api.ApplyInput{}
-		if len(args) > 0 {
-			manifestPath := args[0]
-			input.ManifestPath = &manifestPath
-
-			// We're not necessarily in the workspace root here,
-			// so send the file contents too.
-			bs, err := ioutil.ReadFile(manifestPath)
-			if err != nil {
-				return fmt.Errorf("reading manifest file: %w", err)
-			}
-			s := string(bs)
-			input.Manifest = &s
-		}
-		if applyFlags.Format != "" {
-			input.Format = &applyFlags.Format
-		}
-
-		_, err := workspace.Apply(ctx, input)
-		return err
+		return apply(ctx, workspace, args)
 	},
+}
+
+func apply(ctx context.Context, workspace api.Workspace, args []string) error {
+	input := &api.ApplyInput{}
+	if len(args) > 0 {
+		manifestPath := args[0]
+		input.ManifestPath = &manifestPath
+
+		// We're not necessarily in the workspace root here,
+		// so send the file contents too.
+		bs, err := ioutil.ReadFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("reading manifest file: %w", err)
+		}
+		s := string(bs)
+		input.Manifest = &s
+	}
+	if applyFlags.Format != "" {
+		input.Format = &applyFlags.Format
+	}
+
+	_, err := workspace.Apply(ctx, input)
+	return err
 }

--- a/cmd/exo/gui.go
+++ b/cmd/exo/gui.go
@@ -36,11 +36,11 @@ If the current directory is part of a workspace, navigates to it.`,
 			return fmt.Errorf("finding workspace: %w", err)
 		}
 
-		endpoint := runState.URL
+		var endpoint string
 		if output.ID == nil {
-			endpoint += "#/new-workspace?root=" + url.QueryEscape(cwd)
+			endpoint = runState.URL + "#/new-workspace?root=" + url.QueryEscape(cwd)
 		} else {
-			endpoint += "#/workspaces/" + url.PathEscape(*output.ID)
+			endpoint = guiWorkspaceURL(*output.ID)
 		}
 
 		fmt.Println("Opening GUI:", endpoint)
@@ -48,4 +48,8 @@ If the current directory is part of a workspace, navigates to it.`,
 		browser.Stdout = os.Stderr
 		return browser.OpenURL(endpoint)
 	},
+}
+
+func guiWorkspaceURL(id string) string {
+	return runState.URL + "#/workspaces/" + url.PathEscape(id)
 }

--- a/cmd/exo/logs.go
+++ b/cmd/exo/logs.go
@@ -111,7 +111,11 @@ func tailLogs(ctx context.Context, workspace api.Workspace, logRefs []string) er
 		}
 		in.Cursor = &output.NextCursor
 		if len(output.Items) < 10 { // TODO: OK heuristic?
-			<-time.After(250 * time.Millisecond)
+			select {
+			case <-time.After(250 * time.Millisecond):
+			case <-ctx.Done():
+				return nil
+			}
 		}
 	}
 }

--- a/cmd/exo/run.go
+++ b/cmd/exo/run.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/deref/exo/core/api"
+	"github.com/deref/exo/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+	runCmd.Flags().StringVar(&applyFlags.Format, "format", "", "see `exo help apply`")
+}
+
+var runFlags struct {
+	Format string
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run [flags] [manifest-file]",
+	Short: "Runs all processes and tails their logs",
+	Long: `Runs all processes and tails their logs.
+	
+See 'exo help apply' for details on the manifest arguments.
+	
+If a workspace does not exist, one will be created in the current directory.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := newContext()
+		ensureDaemon()
+		cl := newClient()
+
+		// Ensure workspace.
+		workspace := mustFindWorkspace(ctx, cl)
+		if workspace == nil {
+			output, err := cl.Kernel().CreateWorkspace(ctx, &api.CreateWorkspaceInput{
+				Root: cmdutil.MustGetwd(),
+			})
+			if err != nil {
+				return fmt.Errorf("creating workspace: %w", err)
+			}
+			workspace = cl.GetWorkspace(output.ID)
+		}
+
+		// Advertise GUI URL.
+		{
+			output, err := workspace.Describe(ctx, &api.DescribeInput{})
+			if err != nil {
+				return fmt.Errorf("describing workspace: %w", err)
+			}
+			fmt.Println("GUI available at:", guiWorkspaceURL(output.Description.ID))
+		}
+
+		// Apply manifest.
+		if err := apply(ctx, workspace, args); err != nil {
+			return fmt.Errorf("applying manifest: %w", err)
+		}
+
+		// Tail all logs.
+		var logRefs []string
+		return tailLogs(ctx, workspace, logRefs)
+	},
+}

--- a/cmd/exo/workspace_init.go
+++ b/cmd/exo/workspace_init.go
@@ -32,7 +32,7 @@ will be rooted at the current working directory.`,
 			Root: root,
 		})
 		if err != nil {
-			cmdutil.Fatalf("describing workspaces: %w", err)
+			cmdutil.Fatalf("creating workspace: %w", err)
 		}
 		fmt.Println(output.ID)
 		return nil


### PR DESCRIPTION
This is _mostly_ right. It _always_ stops the workspace after a run. If the workspace is already running, it sort of "takes over" in the sense that it doesn't care if anyone else is running already. It will immediately apply the given manifest, then tail logs, and then stop the workspace on interrupt.

Future work would handle some sort of mutual exclusivity, refusing to run if already started. However, I think this works well enough for initial release.

Note: it's easier to review this if you set the diff tool to ignore whitespace changes.