### PR TITLE
Add check for nil message

### DIFF
--- a/logd/logd.go
+++ b/logd/logd.go
@@ -91,6 +91,9 @@ func syslogToEvent(syslogMessage syslog.Message) (*api.AddEventInput, error) {
 	if rfc5425Message.Appname == nil {
 		return nil, errors.New("expected APP-NAME")
 	}
+	if rfc5425Message.Message == nil {
+		return nil, errors.New("expected MSG")
+	}
 	if rfc5425Message.MsgID == nil {
 		return nil, errors.New("expected MSGID")
 	}


### PR DESCRIPTION
This was causing nil pointer exceptions when trying to start this simple heroku example: https://github.com/heroku/node-js-getting-started