### PR TITLE
IDL model

### DIFF
--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/deref/exo/josh/codegen"
+	"github.com/deref/exo/josh/idl"
+	"github.com/deref/exo/josh/model"
 	"github.com/deref/exo/util/cmdutil"
 )
 
@@ -35,17 +37,14 @@ func main() {
 			return err
 		}
 
-		unit, err := codegen.LoadFile(path)
-		if err != nil {
+		pkgPath := filepath.Join("exo", filepath.Dir(apiDir))
+		pkg := model.NewPackage(pkgPath)
+		idl.LoadFile(pkg, path)
+		if err := pkg.Err(); err != nil {
 			return fmt.Errorf("loading %q: %w", path, err)
 		}
 
-		pkg := &codegen.Package{
-			Path: filepath.Join("exo", filepath.Dir(apiDir)),
-			Unit: *unit,
-		}
-
-		generate := func(dir string, f func(*codegen.Package) ([]byte, error)) error {
+		generate := func(dir string, f func(*model.Package) ([]byte, error)) error {
 			bs, err := f(pkg)
 			if err != nil {
 				return err

--- a/josh/codegen/codgen.go
+++ b/josh/codegen/codgen.go
@@ -67,7 +67,7 @@ import (
 {{template "doc" . -}}
 type {{.Name|public}} interface {
 {{- range .Extends}}
-	{{.|public}}
+	{{.Name|public}}
 {{- end}}
 {{- range .Methods}}
 {{template "doc" . -}}
@@ -86,12 +86,7 @@ type {{.Name|public}}Output struct {
 {{end}}
 
 func Build{{.Name|public}}Mux(b *josh.MuxBuilder, factory func(req *http.Request) {{.Name|public}}) {
-{{- range .Extends}}
-	Build{{.|public}}Mux(b, func(req *http.Request) {{.|public}} {
-		return factory(req)
-	})
-{{- end }}
-{{- range .Methods}}
+{{- range .AllMethods}}
 	b.AddMethod("{{.Name}}", func (req *http.Request) interface{} {
 		return factory(req).{{.Name|public}}
 	})
@@ -132,7 +127,7 @@ func Get{{.Name|public}}(client *josh.Client) *{{.Name|public}} {
 	}
 }
 
-{{range .Methods}}
+{{range .AllMethods}}
 func (c *{{$iface.Name|public}}) {{.Name|public}}(ctx context.Context, input *api.{{.Name|public}}Input) (output *api.{{.Name|public}}Output, err error) {
 	err = c.client.Invoke(ctx, "{{.Name}}", input, &output)
 	return

--- a/josh/idl/elaborate.go
+++ b/josh/idl/elaborate.go
@@ -1,0 +1,49 @@
+package idl
+
+func Elaborate(unit *Unit) {
+	for _, controller := range unit.Controllers {
+		methods := make([]Method, len(controller.Methods))
+		for methodIndex, method := range controller.Methods {
+			shiftInputs := 3
+			inputs := make([]Field, len(method.Inputs)+shiftInputs)
+			inputs[0] = Field{
+				Name: "id",
+				Type: "string",
+			}
+			inputs[1] = Field{
+				Name: "spec",
+				Type: "string",
+			}
+			inputs[2] = Field{
+				Name: "state",
+				Type: "string",
+			}
+			for inputIndex, input := range method.Inputs {
+				inputs[shiftInputs+inputIndex] = input
+			}
+
+			shiftOutputs := 1
+			outputs := make([]Field, len(method.Outputs)+shiftOutputs)
+			outputs[0] = Field{
+				Name: "state",
+				Type: "string",
+			}
+			for outputIndex, output := range method.Outputs {
+				inputs[shiftOutputs+outputIndex] = output
+			}
+
+			methods[methodIndex] = Method{
+				Name:    method.Name,
+				Doc:     method.Doc,
+				Inputs:  inputs,
+				Outputs: outputs,
+			}
+		}
+		unit.Interfaces = append(unit.Interfaces, Interface{
+			Name:    controller.Name,
+			Doc:     controller.Doc,
+			Extends: append([]string{}, controller.Extends...),
+			Methods: methods,
+		})
+	}
+}

--- a/josh/idl/load.go
+++ b/josh/idl/load.go
@@ -21,8 +21,17 @@ func LoadFile(pkg *model.Package, filePath string) {
 	}
 	Elaborate(unit)
 
+	// Declaration pass.
 	for _, ifaceNode := range unit.Interfaces {
-		iface := pkg.DeclareInterface(ifaceNode.Name)
+		pkg.DeclareInterface(ifaceNode.Name)
+	}
+	for _, structNode := range unit.Structs {
+		pkg.DeclareStruct(structNode.Name)
+	}
+
+	// Definition pass.
+	for _, ifaceNode := range unit.Interfaces {
+		iface := pkg.ReferInterface(ifaceNode.Name)
 		if ifaceNode.Doc != nil {
 			iface.SetDoc(*ifaceNode.Doc)
 		}
@@ -67,9 +76,8 @@ func LoadFile(pkg *model.Package, filePath string) {
 			}
 		}
 	}
-
 	for _, structNode := range unit.Structs {
-		strct := pkg.DeclareStruct(structNode.Name)
+		strct := pkg.ReferStruct(structNode.Name)
 		if structNode.Doc != nil {
 			strct.SetDoc(*structNode.Doc)
 		}

--- a/josh/idl/load.go
+++ b/josh/idl/load.go
@@ -27,7 +27,7 @@ func LoadFile(pkg *model.Package, filePath string) {
 			iface.SetDoc(*ifaceNode.Doc)
 		}
 		for _, extendsName := range ifaceNode.Extends {
-			extended := pkg.DeclareInterface(extendsName)
+			extended := pkg.ReferInterface(extendsName)
 			iface.Extend(extended)
 		}
 		for _, methodNode := range ifaceNode.Methods {

--- a/josh/idl/load.go
+++ b/josh/idl/load.go
@@ -1,0 +1,93 @@
+package idl
+
+import (
+	"github.com/deref/exo/josh/model"
+	"github.com/hashicorp/hcl/v2/hclsimple"
+)
+
+func ParseFile(filename string) (*Unit, error) {
+	var unit Unit
+	if err := hclsimple.DecodeFile(filename, nil, &unit); err != nil {
+		return nil, err
+	}
+	return &unit, nil
+}
+
+func LoadFile(pkg *model.Package, filePath string) {
+	unit, err := ParseFile(filePath)
+	if err != nil {
+		pkg.AddError(err)
+		return
+	}
+	Elaborate(unit)
+
+	for _, ifaceNode := range unit.Interfaces {
+		iface := pkg.DeclareInterface(ifaceNode.Name)
+		if ifaceNode.Doc != nil {
+			iface.SetDoc(*ifaceNode.Doc)
+		}
+		for _, extendsName := range ifaceNode.Extends {
+			extended := pkg.DeclareInterface(extendsName)
+			iface.Extend(extended)
+		}
+		for _, methodNode := range ifaceNode.Methods {
+			method := iface.DeclareMethod(methodNode.Name)
+			method.SetDoc(methodNode.Doc)
+			for _, inputNode := range methodNode.Inputs {
+				inputCfg := model.FieldConfig{
+					Name: inputNode.Name,
+					Type: inputNode.Type,
+				}
+				if inputNode.Doc != nil {
+					inputCfg.Doc = *inputNode.Doc
+				}
+				if inputNode.Required != nil {
+					inputCfg.Required = *inputNode.Required
+				}
+				if inputNode.Nullable != nil {
+					inputCfg.Nullable = *inputNode.Nullable
+				}
+				method.AddInput(inputCfg)
+			}
+			for _, outputNode := range methodNode.Outputs {
+				outputCfg := model.FieldConfig{
+					Name: outputNode.Name,
+					Type: outputNode.Type,
+				}
+				if outputNode.Doc != nil {
+					outputCfg.Doc = *outputNode.Doc
+				}
+				if outputNode.Required != nil {
+					outputCfg.Required = *outputNode.Required
+				}
+				if outputNode.Nullable != nil {
+					outputCfg.Nullable = *outputNode.Nullable
+				}
+				method.AddOutput(outputCfg)
+			}
+		}
+	}
+
+	for _, structNode := range unit.Structs {
+		strct := pkg.DeclareStruct(structNode.Name)
+		if structNode.Doc != nil {
+			strct.SetDoc(*structNode.Doc)
+		}
+		for _, fieldNode := range structNode.Fields {
+			fieldCfg := model.FieldConfig{
+				Name: fieldNode.Name,
+				Type: fieldNode.Type,
+			}
+			if fieldNode.Doc != nil {
+				fieldCfg.Doc = *fieldNode.Doc
+			}
+			if fieldNode.Required != nil {
+				fieldCfg.Required = *fieldNode.Required
+			}
+			if fieldNode.Nullable != nil {
+				fieldCfg.Nullable = *fieldNode.Nullable
+			}
+			strct.AddField(fieldCfg)
+		}
+	}
+}

--- a/josh/idl/types.go
+++ b/josh/idl/types.go
@@ -1,0 +1,47 @@
+package idl
+
+type Package struct {
+	Path string
+	Unit
+}
+
+type Unit struct {
+	Interfaces  []Interface  `hcl:"interface,block"`
+	Structs     []Struct     `hcl:"struct,block"`
+	Controllers []Controller `hcl:"controller,block"`
+}
+
+type Interface struct {
+	Name    string   `hcl:"name,label"`
+	Doc     *string  `hcl:"doc"`
+	Extends []string `hcl:"extends,optional"`
+	Methods []Method `hcl:"method,block"`
+}
+
+type Method struct {
+	Name    string  `hcl:"name,label"`
+	Doc     *string `hcl:"doc"`
+	Inputs  []Field `hcl:"input,block"`
+	Outputs []Field `hcl:"output,block"`
+}
+
+type Struct struct {
+	Name   string  `hcl:"name,label"`
+	Doc    *string `hcl:"doc"`
+	Fields []Field `hcl:"field,block"`
+}
+
+type Field struct {
+	Name     string  `hcl:"name,label"`
+	Doc      *string `hcl:"doc"`
+	Type     string  `hcl:"type,label"`
+	Required *bool   `hcl:"required"`
+	Nullable *bool   `hcl:"nullable"`
+}
+
+type Controller struct {
+	Name    string   `hcl:"name,label"`
+	Doc     *string  `hcl:"doc"`
+	Extends []string `hcl:"extends,optional"`
+	Methods []Method `hcl:"method,block"`
+}

--- a/josh/model/field.go
+++ b/josh/model/field.go
@@ -1,0 +1,33 @@
+package model
+
+type Field struct {
+	cfg FieldConfig
+}
+
+type FieldConfig struct {
+	Name     string
+	Doc      string
+	Type     string // TODO: Type type.
+	Required bool
+	Nullable bool
+}
+
+func (field *Field) Name() string {
+	return field.cfg.Name
+}
+
+func (field *Field) Doc() string {
+	return field.cfg.Doc
+}
+
+func (field *Field) Type() string {
+	return field.cfg.Type
+}
+
+func (field *Field) Required() bool {
+	return field.cfg.Required
+}
+
+func (field *Field) Nullable() bool {
+	return field.cfg.Nullable
+}

--- a/josh/model/interface.go
+++ b/josh/model/interface.go
@@ -49,6 +49,26 @@ func (iface *Interface) Methods() []*Method {
 	return methods
 }
 
+func (iface *Interface) AllMethods() []*Method {
+	visited := make(map[*Interface]bool)
+	var methods []*Method
+	iface.collectMethods(visited, &methods)
+	return methods
+}
+
+func (iface *Interface) collectMethods(visited map[*Interface]bool, methods *[]*Method) {
+	for _, extended := range iface.extends {
+		if visited[extended] {
+			continue
+		}
+		visited[extended] = true
+		extended.collectMethods(visited, methods)
+	}
+	for _, method := range iface.methods {
+		*methods = append(*methods, method)
+	}
+}
+
 func (iface *Interface) DeclareMethod(name string) *Method {
 	method := &Method{
 		iface: iface,

--- a/josh/model/interface.go
+++ b/josh/model/interface.go
@@ -1,0 +1,59 @@
+package model
+
+import "fmt"
+
+type Interface struct {
+	pkg     *Package
+	name    string
+	doc     string
+	extends []*Interface
+	methods []*Method
+}
+
+func newInterface(pkg *Package, name string) *Interface {
+	return &Interface{
+		pkg:  pkg,
+		name: name,
+	}
+}
+
+func (iface *Interface) AddError(err error) {
+	iface.pkg.AddError(fmt.Errorf("interface %q: %w", iface.name, err))
+}
+
+func (iface *Interface) Name() string {
+	return iface.name
+}
+
+func (iface *Interface) SetDoc(value string) {
+	iface.doc = value
+}
+
+func (iface *Interface) Doc() string {
+	return iface.doc
+}
+
+func (iface *Interface) Extends() []*Interface {
+	extends := make([]*Interface, len(iface.extends))
+	copy(extends, iface.extends)
+	return extends
+}
+
+func (iface *Interface) Extend(extended *Interface) {
+	iface.extends = append(iface.extends, extended)
+}
+
+func (iface *Interface) Methods() []*Method {
+	methods := make([]*Method, len(iface.methods))
+	copy(methods, iface.methods)
+	return methods
+}
+
+func (iface *Interface) DeclareMethod(name string) *Method {
+	method := &Method{
+		iface: iface,
+		name:  name,
+	}
+	iface.methods = append(iface.methods, method)
+	return method
+}

--- a/josh/model/method.go
+++ b/josh/model/method.go
@@ -1,0 +1,45 @@
+package model
+
+type Method struct {
+	iface   *Interface
+	name    string
+	doc     *string
+	inputs  []*Field
+	outputs []*Field
+}
+
+func (method *Method) Name() string {
+	return method.name
+}
+
+func (method *Method) SetDoc(value *string) {
+	method.doc = value
+}
+
+func (method *Method) Doc() *string {
+	return method.doc
+}
+
+func (method *Method) Inputs() []*Field {
+	inputs := make([]*Field, len(method.inputs))
+	copy(inputs, method.inputs)
+	return inputs
+}
+
+func (method *Method) Outputs() []*Field {
+	outputs := make([]*Field, len(method.outputs))
+	copy(outputs, method.outputs)
+	return outputs
+}
+
+func (method *Method) AddInput(cfg FieldConfig) *Field {
+	field := &Field{cfg: cfg}
+	method.inputs = append(method.inputs, field)
+	return field
+}
+
+func (method *Method) AddOutput(cfg FieldConfig) *Field {
+	field := &Field{cfg: cfg}
+	method.outputs = append(method.outputs, field)
+	return field
+}

--- a/josh/model/package.go
+++ b/josh/model/package.go
@@ -1,0 +1,86 @@
+package model
+
+import "fmt"
+
+type Package struct {
+	path    string
+	members []interface{}
+	names   map[string]Named
+	errors  []error
+}
+
+type Named interface {
+	Name() string
+}
+
+func NewPackage(path string) *Package {
+	return &Package{
+		path:  path,
+		names: make(map[string]Named),
+	}
+}
+
+func (pkg *Package) Path() string {
+	return pkg.path
+}
+
+func (pkg *Package) Err() error {
+	if len(pkg.errors) > 0 {
+		return pkg.errors[0]
+	}
+	return nil
+}
+
+func (pkg *Package) DeclareInterface(name string) *Interface {
+	named := pkg.names[name]
+	if named == nil {
+		named = newInterface(pkg, name)
+		pkg.names[name] = named
+	}
+	iface, ok := named.(*Interface)
+	if !ok {
+		pkg.AddError(fmt.Errorf("conflicting declarations for %q", name))
+		iface = newInterface(pkg, name)
+	}
+	pkg.members = append(pkg.members, iface)
+	return iface
+}
+
+func (pkg *Package) DeclareStruct(name string) *Struct {
+	named := pkg.names[name]
+	if named == nil {
+		named = newStruct(pkg, name)
+		pkg.names[name] = named
+	}
+	strct, ok := named.(*Struct)
+	if !ok {
+		pkg.AddError(fmt.Errorf("conflicting declarations for %q", name))
+		strct = newStruct(pkg, name)
+	}
+	pkg.members = append(pkg.members, strct)
+	return strct
+}
+
+func (pkg *Package) Interfaces() []*Interface {
+	ifaces := make([]*Interface, 0, len(pkg.names))
+	for _, named := range pkg.members {
+		if iface, ok := named.(*Interface); ok {
+			ifaces = append(ifaces, iface)
+		}
+	}
+	return ifaces
+}
+
+func (pkg *Package) AddError(err error) {
+	pkg.errors = append(pkg.errors, err)
+}
+
+func (pkg *Package) Structs() []*Struct {
+	structs := make([]*Struct, 0, len(pkg.names))
+	for _, named := range pkg.members {
+		if strct, ok := named.(*Struct); ok {
+			structs = append(structs, strct)
+		}
+	}
+	return structs
+}

--- a/josh/model/package.go
+++ b/josh/model/package.go
@@ -32,7 +32,7 @@ func (pkg *Package) Err() error {
 }
 
 func (pkg *Package) DeclareInterface(name string) *Interface {
-	named := pkg.names[name]
+	named, ok := pkg.names[name]
 	if named == nil {
 		named = newInterface(pkg, name)
 		pkg.names[name] = named
@@ -72,6 +72,20 @@ func (pkg *Package) DeclareStruct(name string) *Struct {
 		strct = newStruct(pkg, name)
 	}
 	pkg.members = append(pkg.members, strct)
+	return strct
+}
+
+func (pkg *Package) ReferStruct(name string) *Struct {
+	named := pkg.names[name]
+	strct, ok := named.(*Struct)
+	if !ok {
+		if named == nil {
+			pkg.AddError(fmt.Errorf("undefined struct: %q", name))
+		} else {
+			pkg.AddError(fmt.Errorf("expected %q to be a struct", name))
+		}
+		strct = newStruct(pkg, name)
+	}
 	return strct
 }
 

--- a/josh/model/package.go
+++ b/josh/model/package.go
@@ -46,6 +46,20 @@ func (pkg *Package) DeclareInterface(name string) *Interface {
 	return iface
 }
 
+func (pkg *Package) ReferInterface(name string) *Interface {
+	named := pkg.names[name]
+	iface, ok := named.(*Interface)
+	if !ok {
+		if named == nil {
+			pkg.AddError(fmt.Errorf("undefined interface: %q", name))
+		} else {
+			pkg.AddError(fmt.Errorf("expected %q to be an interface", name))
+		}
+		iface = newInterface(pkg, name)
+	}
+	return iface
+}
+
 func (pkg *Package) DeclareStruct(name string) *Struct {
 	named := pkg.names[name]
 	if named == nil {
@@ -62,7 +76,7 @@ func (pkg *Package) DeclareStruct(name string) *Struct {
 }
 
 func (pkg *Package) Interfaces() []*Interface {
-	ifaces := make([]*Interface, 0, len(pkg.names))
+	ifaces := make([]*Interface, 0, len(pkg.members))
 	for _, named := range pkg.members {
 		if iface, ok := named.(*Interface); ok {
 			ifaces = append(ifaces, iface)
@@ -76,7 +90,7 @@ func (pkg *Package) AddError(err error) {
 }
 
 func (pkg *Package) Structs() []*Struct {
-	structs := make([]*Struct, 0, len(pkg.names))
+	structs := make([]*Struct, 0, len(pkg.members))
 	for _, named := range pkg.members {
 		if strct, ok := named.(*Struct); ok {
 			structs = append(structs, strct)

--- a/josh/model/struct.go
+++ b/josh/model/struct.go
@@ -1,0 +1,39 @@
+package model
+
+type Struct struct {
+	pkg    *Package
+	name   string
+	doc    string
+	fields []*Field
+}
+
+func newStruct(pkg *Package, name string) *Struct {
+	return &Struct{
+		pkg:  pkg,
+		name: name,
+	}
+}
+
+func (strct *Struct) Name() string {
+	return strct.name
+}
+
+func (strct *Struct) SetDoc(value string) {
+	strct.doc = value
+}
+
+func (strct *Struct) Doc() string {
+	return strct.doc
+}
+
+func (strct *Struct) Fields() []*Field {
+	fields := make([]*Field, len(strct.fields))
+	copy(fields, strct.fields)
+	return fields
+}
+
+func (strct *Struct) AddField(cfg FieldConfig) *Field {
+	field := &Field{cfg: cfg}
+	strct.fields = append(strct.fields, field)
+	return field
+}


### PR DESCRIPTION
This PR does two major things:

(A) This splits the existing IDL codegen bits in to three parts: 1) parsing the HCL 2) a deeply interlinked append-only "model" and 3) the actual code templating
(B) Introduces a notion of "extends" a la Go interface embedding.

The model supports interface embedding.

Motivation: Allows workspace to extend process (in a follow-up PR), so that I can start/stop/restart a whole workspace.