### PR TITLE
dependency injection & internal logging improvements

### DIFF
--- a/cmd/exo/root.go
+++ b/cmd/exo/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/deref/exo/config"
 	"github.com/deref/exo/util/cmdutil"
+	"github.com/deref/exo/util/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +26,14 @@ For more information, see https://exo.deref.io`,
 }
 
 func newContext() context.Context {
-	return config.WithConfig(context.Background(), cfg)
+	ctx := context.Background()
+
+	ctx = config.WithConfig(ctx, cfg)
+
+	logger := logging.Default()
+	ctx = logging.ContextWithLogger(ctx, logger)
+
+	return ctx
 }
 
 func main() {

--- a/cmd/exo/run.go
+++ b/cmd/exo/run.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 
 	"github.com/deref/exo/core/api"
 	"github.com/deref/exo/util/cmdutil"
+	"github.com/deref/exo/util/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +33,7 @@ If a workspace does not exist, one will be created in the current directory.
 		ctx := newContext()
 		ensureDaemon()
 		cl := newClient()
+		logger := logging.CurrentLogger(ctx)
 
 		// Ensure workspace.
 		workspace := mustFindWorkspace(ctx, cl)
@@ -66,7 +67,7 @@ If a workspace does not exist, one will be created in the current directory.
 			defer stop()
 			var logRefs []string
 			if err := tailLogs(ctx, workspace, logRefs); err != nil {
-				log.Printf("error tailing logs: %v", err)
+				logger.Infof("error tailing logs: %v", err)
 			}
 		})()
 

--- a/cmd/exo/server.go
+++ b/cmd/exo/server.go
@@ -18,6 +18,7 @@ var serverCmd = &cobra.Command{
 Prefer the daemonize command for normal operation.`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		exod.Main()
+		ctx := newContext()
+		exod.Main(ctx)
 	},
 }

--- a/cmd/exod/main.go
+++ b/cmd/exod/main.go
@@ -4,9 +4,14 @@
 package main
 
 import (
+	"context"
+
 	"github.com/deref/exo/exod"
+	"github.com/deref/exo/util/logging"
 )
 
 func main() {
-	exod.Main()
+	ctx := context.Background()
+	ctx = logging.ContextWithLogger(ctx, logging.Default())
+	exod.Main(ctx)
 }

--- a/cmd/exop/main.go
+++ b/cmd/exop/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/deref/exo/telemetry"
 	"github.com/deref/exo/util/cmdutil"
 	"github.com/deref/exo/util/httputil"
+	"github.com/deref/exo/util/logging"
 	"github.com/deref/pier"
 )
 
@@ -40,6 +41,8 @@ func main() {
 
 	ctx := context.Background()
 
+	logger := logging.Default()
+
 	cfg := &config.Config{}
 	config.MustLoadDefault(cfg)
 	paths := cmdutil.MustMakeDirectories(cfg)
@@ -52,6 +55,7 @@ func main() {
 		Store:      store,
 		Telemetry:  telemetry.New(&cfg.Telemetry),
 		SyslogPort: log.SyslogPort,
+		Logger:     logger,
 	}
 
 	ctx = log.ContextWithLogCollector(ctx, logd.GetLogCollector(&josh.Client{

--- a/cmd/logd/main.go
+++ b/cmd/logd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/deref/exo/logd"
 	"github.com/deref/exo/logd/api"
 	"github.com/deref/exo/util/cmdutil"
+	"github.com/deref/exo/util/logging"
 )
 
 func main() {
@@ -31,6 +32,7 @@ func main() {
 	paths := cmdutil.MustMakeDirectories(cfg)
 
 	logd := &logd.Service{}
+	logd.Logger = logging.Default()
 	logd.Debug = true
 	logd.VarDir = paths.VarDir
 

--- a/cmd/logp/main.go
+++ b/cmd/logp/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/deref/exo/logd"
 	"github.com/deref/exo/logd/api"
 	"github.com/deref/exo/util/cmdutil"
+	"github.com/deref/exo/util/logging"
 	"github.com/deref/pier"
 )
 
@@ -26,6 +27,7 @@ func main() {
 	paths := cmdutil.MustMakeDirectories(cfg)
 
 	logd := &logd.Service{}
+	logd.Logger = logging.Default()
 	logd.VarDir = paths.VarDir
 
 	{

--- a/core/server/handler.go
+++ b/core/server/handler.go
@@ -7,6 +7,7 @@ import (
 	state "github.com/deref/exo/core/state/api"
 	josh "github.com/deref/exo/josh/server"
 	"github.com/deref/exo/telemetry"
+	"github.com/deref/exo/util/logging"
 	docker "github.com/docker/docker/client"
 )
 
@@ -16,6 +17,7 @@ type Config struct {
 	Telemetry  telemetry.Telemetry
 	SyslogPort int
 	Docker     *docker.Client
+	Logger     logging.Logger
 }
 
 func BuildRootMux(prefix string, cfg *Config) *http.ServeMux {
@@ -36,6 +38,7 @@ func BuildRootMux(prefix string, cfg *Config) *http.ServeMux {
 		return &Workspace{
 			ID:         req.URL.Query().Get("id"),
 			VarDir:     cfg.VarDir,
+			Logger:     cfg.Logger,
 			Store:      cfg.Store,
 			SyslogPort: cfg.SyslogPort,
 			Docker:     cfg.Docker,

--- a/core/server/workspace.go
+++ b/core/server/workspace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/deref/exo/providers/unix/components/process"
 	"github.com/deref/exo/util/errutil"
 	"github.com/deref/exo/util/jsonutil"
+	"github.com/deref/exo/util/logging"
 	docker "github.com/docker/docker/client"
 )
 
@@ -30,6 +31,7 @@ type Workspace struct {
 	VarDir     string
 	Store      state.Store
 	SyslogPort int
+	Logger     logging.Logger
 	Docker     *docker.Client
 }
 
@@ -220,6 +222,7 @@ func (ws *Workspace) newController(ctx context.Context, typ string) Controller {
 			}
 		}
 		return &container.Container{
+			Logger:        ws.Logger,
 			WorkspaceRoot: description.Root,
 			Docker:        ws.Docker,
 			SyslogPort:    ws.SyslogPort,

--- a/core/server/workspace.go
+++ b/core/server/workspace.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/deref/exo/chrono"
 	"github.com/deref/exo/core/api"
-	core "github.com/deref/exo/core/api"
 	state "github.com/deref/exo/core/state/api"
 	"github.com/deref/exo/gensym"
 	logd "github.com/deref/exo/logd/api"
 	"github.com/deref/exo/manifest"
+	"github.com/deref/exo/providers/core"
 	"github.com/deref/exo/providers/core/components/invalid"
 	"github.com/deref/exo/providers/core/components/log"
+	"github.com/deref/exo/providers/docker"
 	"github.com/deref/exo/providers/docker/components/container"
 	"github.com/deref/exo/providers/docker/components/network"
 	"github.com/deref/exo/providers/docker/components/volume"
@@ -23,7 +24,7 @@ import (
 	"github.com/deref/exo/util/errutil"
 	"github.com/deref/exo/util/jsonutil"
 	"github.com/deref/exo/util/logging"
-	docker "github.com/docker/docker/client"
+	dockerclient "github.com/docker/docker/client"
 )
 
 type Workspace struct {
@@ -32,7 +33,7 @@ type Workspace struct {
 	Store      state.Store
 	SyslogPort int
 	Logger     logging.Logger
-	Docker     *docker.Client
+	Docker     *dockerclient.Client
 }
 
 func (ws *Workspace) Describe(ctx context.Context, input *api.DescribeInput) (*api.DescribeOutput, error) {
@@ -137,7 +138,7 @@ func (ws *Workspace) Apply(ctx context.Context, input *api.ApplyInput) (*api.App
 		}
 	}
 
-	return &core.ApplyOutput{
+	return &api.ApplyOutput{
 		Warnings: res.Warnings,
 	}, nil
 }
@@ -201,41 +202,47 @@ func (ws *Workspace) DescribeComponents(ctx context.Context, input *api.Describe
 }
 
 func (ws *Workspace) newController(ctx context.Context, typ string) Controller {
+	description, err := ws.describe(ctx)
+	if err != nil {
+		return &invalid.Invalid{
+			Err: fmt.Errorf("workspace error: %w", err),
+		}
+	}
+	component := core.Component{
+		ComponentID:   description.ID,
+		WorkspaceRoot: description.Root,
+		Logger:        ws.Logger,
+	}
 	switch typ {
 	case "process":
-		description, err := ws.describe(ctx)
-		if err != nil {
-			return &invalid.Invalid{
-				Err: fmt.Errorf("workspace error: %w", err),
-			}
-		}
 		return &process.Process{
-			WorkspaceRoot: description.Root,
-			SyslogPort:    ws.SyslogPort,
+			Component:  component,
+			SyslogPort: ws.SyslogPort,
 		}
 
 	case "container":
-		description, err := ws.describe(ctx)
-		if err != nil {
-			return &invalid.Invalid{
-				Err: fmt.Errorf("workspace error: %w", err),
-			}
-		}
 		return &container.Container{
-			Logger:        ws.Logger,
-			WorkspaceRoot: description.Root,
-			Docker:        ws.Docker,
-			SyslogPort:    ws.SyslogPort,
+			Component: docker.Component{
+				Component: component,
+				Docker:    ws.Docker,
+			},
+			SyslogPort: ws.SyslogPort,
 		}
 
 	case "network":
 		return &network.Network{
-			Docker: ws.Docker,
+			Component: docker.Component{
+				Component: component,
+				Docker:    ws.Docker,
+			},
 		}
 
 	case "volume":
 		return &volume.Volume{
-			Docker: ws.Docker,
+			Component: docker.Component{
+				Component: component,
+				Docker:    ws.Docker,
+			},
 		}
 
 	default:
@@ -285,7 +292,7 @@ func (ws *Workspace) createComponent(ctx context.Context, component manifest.Com
 		Type: component.Type,
 		Spec: component.Spec,
 	}, func(lifecycle api.Lifecycle) error {
-		_, err := lifecycle.Initialize(ctx, &core.InitializeInput{})
+		_, err := lifecycle.Initialize(ctx, &api.InitializeInput{})
 		return err
 	}); err != nil {
 		return "", err
@@ -346,7 +353,7 @@ func (ws *Workspace) RefreshComponent(ctx context.Context, input *api.RefreshCom
 
 func (ws *Workspace) refreshComponent(ctx context.Context, store state.Store, component state.ComponentDescription) error {
 	return ws.control(ctx, component, func(lifecycle api.Lifecycle) error {
-		_, err := lifecycle.Refresh(ctx, &core.RefreshInput{})
+		_, err := lifecycle.Refresh(ctx, &api.RefreshInput{})
 		return err
 	})
 }
@@ -385,7 +392,7 @@ func (ws *Workspace) disposeComponent(ctx context.Context, id string) error {
 	}
 	component := describeOutput.Components[0]
 	return ws.control(ctx, component, func(lifecycle api.Lifecycle) error {
-		_, err := lifecycle.Dispose(ctx, &core.DisposeInput{})
+		_, err := lifecycle.Dispose(ctx, &api.DisposeInput{})
 		return err
 	})
 }
@@ -534,12 +541,12 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 
 func (ws *Workspace) Start(ctx context.Context, input *api.StartInput) (*api.StartOutput, error) {
 	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
-		_, err := process.Start(ctx, &core.StartInput{})
+		_, err := process.Start(ctx, &api.StartInput{})
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return &core.StartOutput{}, nil
+	return &api.StartOutput{}, nil
 }
 
 func (ws *Workspace) StartComponent(ctx context.Context, input *api.StartComponentInput) (*api.StartComponentOutput, error) {
@@ -561,7 +568,7 @@ func (ws *Workspace) StartComponent(ctx context.Context, input *api.StartCompone
 	component := components.Components[0]
 
 	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Start(ctx, &core.StartInput{})
+		_, err := process.Start(ctx, &api.StartInput{})
 		return err
 	}); err != nil {
 		return nil, err
@@ -571,12 +578,12 @@ func (ws *Workspace) StartComponent(ctx context.Context, input *api.StartCompone
 
 func (ws *Workspace) Stop(ctx context.Context, input *api.StopInput) (*api.StopOutput, error) {
 	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
-		_, err := process.Stop(ctx, &core.StopInput{})
+		_, err := process.Stop(ctx, &api.StopInput{})
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return &core.StopOutput{}, nil
+	return &api.StopOutput{}, nil
 }
 
 func (ws *Workspace) StopComponent(ctx context.Context, input *api.StopComponentInput) (*api.StopComponentOutput, error) {
@@ -598,7 +605,7 @@ func (ws *Workspace) StopComponent(ctx context.Context, input *api.StopComponent
 	component := components.Components[0]
 
 	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Stop(ctx, &core.StopInput{})
+		_, err := process.Stop(ctx, &api.StopInput{})
 		return err
 	}); err != nil {
 		return nil, err
@@ -608,12 +615,12 @@ func (ws *Workspace) StopComponent(ctx context.Context, input *api.StopComponent
 
 func (ws *Workspace) Restart(ctx context.Context, input *api.RestartInput) (*api.RestartOutput, error) {
 	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
-		_, err := process.Restart(ctx, &core.RestartInput{})
+		_, err := process.Restart(ctx, &api.RestartInput{})
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return &core.RestartOutput{}, nil
+	return &api.RestartOutput{}, nil
 }
 
 func (ws *Workspace) RestartComponent(ctx context.Context, input *api.RestartComponentInput) (*api.RestartComponentOutput, error) {
@@ -635,7 +642,7 @@ func (ws *Workspace) RestartComponent(ctx context.Context, input *api.RestartCom
 	component := components.Components[0]
 
 	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Restart(ctx, &core.RestartInput{})
+		_, err := process.Restart(ctx, &api.RestartInput{})
 		return err
 	}); err != nil {
 		return nil, err

--- a/josh/server/introspection.go
+++ b/josh/server/introspection.go
@@ -30,5 +30,5 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 			Name: methodName,
 		})
 	}
-	httputil.WriteJSON(w, http.StatusOK, output)
+	httputil.WriteJSON(w, req, http.StatusOK, output)
 }

--- a/logd/store/badger/log.go
+++ b/logd/store/badger/log.go
@@ -5,19 +5,18 @@
 package badger
 
 import (
-	"log"
-
+	"github.com/deref/exo/util/logging"
 	"github.com/dgraph-io/badger/v3"
 )
 
 type logger struct {
-	underlying *log.Logger
+	underlying logging.Logger
 	level      int
 }
 
 const defaultLogLevel = int(badger.INFO)
 
-func newLogger(underlying *log.Logger, level int) badger.Logger {
+func newLogger(underlying logging.Logger, level int) badger.Logger {
 	return &logger{
 		underlying: underlying,
 		level:      level,
@@ -25,7 +24,7 @@ func newLogger(underlying *log.Logger, level int) badger.Logger {
 }
 
 func (l *logger) Printf(f string, v ...interface{}) {
-	l.underlying.Printf("badger "+f, v...)
+	l.underlying.Infof("badger "+f, v...)
 }
 
 func (l *logger) Errorf(f string, v ...interface{}) {

--- a/logd/store/badger/store.go
+++ b/logd/store/badger/store.go
@@ -2,10 +2,10 @@ package badger
 
 import (
 	"context"
-	"log"
 
 	"github.com/deref/exo/gensym"
 	"github.com/deref/exo/logd/store"
+	"github.com/deref/exo/util/logging"
 	"github.com/dgraph-io/badger/v3"
 )
 
@@ -20,10 +20,13 @@ type Log struct {
 	name  string
 }
 
-func Open(ctx context.Context, logsDir string) (*Store, error) {
+// Ambiguous notions of "logs" here.
+// logger is for Badger logging.
+// logsDir is where the logs we're capturing are being stored.
+func Open(ctx context.Context, logger logging.Logger, logsDir string) (*Store, error) {
 	db, err := badger.Open(
 		badger.DefaultOptions(logsDir).
-			WithLogger(newLogger(log.Default(), defaultLogLevel)),
+			WithLogger(newLogger(logger, defaultLogLevel)),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/core/component.go
+++ b/providers/core/component.go
@@ -1,0 +1,9 @@
+package core
+
+import "github.com/deref/exo/util/logging"
+
+type Component struct {
+	ComponentID   string
+	WorkspaceRoot string
+	Logger        logging.Logger
+}

--- a/providers/docker/component.go
+++ b/providers/docker/component.go
@@ -1,0 +1,11 @@
+package docker
+
+import (
+	"github.com/deref/exo/providers/core"
+	dockerclient "github.com/docker/docker/client"
+)
+
+type Component struct {
+	core.Component
+	Docker *dockerclient.Client
+}

--- a/providers/docker/components/container/component.go
+++ b/providers/docker/components/container/component.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"github.com/deref/exo/providers/docker/compose"
+	"github.com/deref/exo/util/logging"
 	docker "github.com/docker/docker/client"
 )
 
@@ -10,6 +11,7 @@ type Container struct {
 	Spec
 	State
 
+	Logger        logging.Logger
 	WorkspaceRoot string
 	Docker        *docker.Client
 	SyslogPort    int

--- a/providers/docker/components/container/component.go
+++ b/providers/docker/components/container/component.go
@@ -1,20 +1,16 @@
 package container
 
 import (
+	"github.com/deref/exo/providers/docker"
 	"github.com/deref/exo/providers/docker/compose"
-	"github.com/deref/exo/util/logging"
-	docker "github.com/docker/docker/client"
 )
 
 type Container struct {
-	ComponentID string
+	docker.Component
 	Spec
 	State
 
-	Logger        logging.Logger
-	WorkspaceRoot string
-	Docker        *docker.Client
-	SyslogPort    int
+	SyslogPort int
 }
 
 type Spec compose.Service

--- a/providers/docker/components/container/lifecycle.go
+++ b/providers/docker/components/container/lifecycle.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	core "github.com/deref/exo/core/api"
@@ -26,7 +25,7 @@ func (c *Container) Initialize(ctx context.Context, input *core.InitializeInput)
 	}
 
 	if err := c.start(ctx); err != nil {
-		log.Printf("starting container %q: %v", c.ContainerID, err)
+		c.Logger.Infof("starting container %q: %v", c.ContainerID, err)
 	}
 
 	return &core.InitializeOutput{}, nil
@@ -216,7 +215,7 @@ func (c *Container) Dispose(ctx context.Context, input *core.DisposeInput) (*cor
 		return &core.DisposeOutput{}, nil
 	}
 	if err := c.stop(ctx); err != nil {
-		log.Printf("stopping container %q: %v", c.ContainerID, err)
+		c.Logger.Infof("stopping container %q: %v", c.ContainerID, err)
 	}
 	err := c.Docker.ContainerRemove(ctx, c.ContainerID, types.ContainerRemoveOptions{
 		// XXX RemoveVolumes: ???,
@@ -224,7 +223,7 @@ func (c *Container) Dispose(ctx context.Context, input *core.DisposeInput) (*cor
 		Force: true, // OK?
 	})
 	if docker.IsErrNotFound(err) {
-		log.Printf("disposing container not found: %q", c.ContainerID)
+		c.Logger.Infof("disposing container not found: %q", c.ContainerID)
 		err = nil
 	}
 	if err != nil {

--- a/providers/docker/components/network/component.go
+++ b/providers/docker/components/network/component.go
@@ -1,16 +1,14 @@
 package network
 
 import (
+	"github.com/deref/exo/providers/docker"
 	"github.com/deref/exo/providers/docker/compose"
-	docker "github.com/docker/docker/client"
 )
 
 type Network struct {
-	ComponentID string
+	docker.Component
 	Spec
 	State
-
-	Docker *docker.Client
 }
 
 type Spec compose.Network

--- a/providers/docker/components/volume/component.go
+++ b/providers/docker/components/volume/component.go
@@ -1,16 +1,14 @@
 package volume
 
 import (
+	"github.com/deref/exo/providers/docker"
 	"github.com/deref/exo/providers/docker/compose"
-	docker "github.com/docker/docker/client"
 )
 
 type Volume struct {
-	ComponentID string
+	docker.Component
 	Spec
 	State
-
-	Docker *docker.Client
 }
 
 type Spec compose.Volume

--- a/providers/unix/components/process/component.go
+++ b/providers/unix/components/process/component.go
@@ -1,12 +1,13 @@
 package process
 
+import "github.com/deref/exo/providers/core"
+
 type Process struct {
-	ComponentID string
+	core.Component
 	Spec
 	State
 
-	WorkspaceRoot string
-	SyslogPort    int
+	SyslogPort int
 }
 
 type Spec struct {

--- a/providers/unix/components/process/process.go
+++ b/providers/unix/components/process/process.go
@@ -163,7 +163,7 @@ func (p *Process) stop() {
 	}
 	p.Pid = 0
 	if err := proc.Signal(os.Interrupt); err != nil {
-		// TODO: Report the error somehow?
+		p.Logger.Infof("interrupt failed: %w", err)
 	}
 }
 

--- a/util/httputil/context.go
+++ b/util/httputil/context.go
@@ -3,10 +3,55 @@ package httputil
 import (
 	"context"
 	"net/http"
+	"time"
+
+	"github.com/deref/exo/chrono"
+	"github.com/deref/exo/gensym"
+	"github.com/deref/exo/util/logging"
 )
 
 func HandlerWithContext(ctx context.Context, handler http.Handler) http.Handler {
+	logger := logging.CurrentLogger(ctx)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		handler.ServeHTTP(w, req.WithContext(ctx))
+		requestID := gensym.RandomBase32()
+		sl := logger.Sublogger("http " + requestID)
+		sl.Infof("%s %s", req.Method, req.URL)
+		ctx := logging.ContextWithLogger(ctx, sl)
+		start := chrono.Now(ctx)
+		logw := &responseLogger{rw: w}
+		handler.ServeHTTP(logw, req.WithContext(ctx))
+		end := chrono.Now(ctx)
+		duration := end.Sub(start).Truncate(time.Millisecond)
+		sl.Infof("status %d - %s", logw.status, duration)
 	})
+}
+
+type responseLogger struct {
+	rw     http.ResponseWriter
+	status int
+	size   int
+}
+
+func (rl *responseLogger) Header() http.Header {
+	return rl.rw.Header()
+}
+
+func (rl *responseLogger) Write(bytes []byte) (int, error) {
+	if rl.status == 0 {
+		rl.status = http.StatusOK
+	}
+	size, err := rl.rw.Write(bytes)
+	rl.size += size
+	return size, err
+}
+
+func (rl *responseLogger) WriteHeader(status int) {
+	rl.status = status
+	rl.rw.WriteHeader(status)
+}
+
+func (rl *responseLogger) Flush() {
+	if f, ok := rl.rw.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/util/httputil/error.go
+++ b/util/httputil/error.go
@@ -4,11 +4,11 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"text/template"
 
 	"github.com/deref/exo/util/errutil"
+	"github.com/deref/exo/util/logging"
 	accept "github.com/timewasted/go-accept-headers"
 )
 
@@ -20,14 +20,15 @@ func WriteError(w http.ResponseWriter, req *http.Request, err error) {
 		status = httpErr.HTTPStatus()
 		message = err.Error()
 	}
+	logger := logging.CurrentLogger(req.Context())
 	if status == http.StatusInternalServerError {
-		log.Printf("error processing request: %v", err)
+		logger.Infof("error processing request: %v", err)
 	}
 
 	contentType, _ := accept.Negotiate(req.Header.Get("accept"), "application/json", "text/html", "text/plain")
 	switch contentType {
 	case "application/json":
-		WriteJSON(w, status, map[string]interface{}{
+		WriteJSON(w, req, status, map[string]interface{}{
 			"status":  status,
 			"message": message,
 		})

--- a/util/httputil/write.go
+++ b/util/httputil/write.go
@@ -3,8 +3,9 @@ package httputil
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"net/http"
+
+	"github.com/deref/exo/util/logging"
 )
 
 func WriteString(w http.ResponseWriter, status int, s string) {
@@ -13,11 +14,12 @@ func WriteString(w http.ResponseWriter, status int, s string) {
 	io.WriteString(w, s)
 }
 
-func WriteJSON(w http.ResponseWriter, status int, v interface{}) {
+func WriteJSON(w http.ResponseWriter, req *http.Request, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(v); err != nil {
-		log.Printf("error encoding response: %v", err)
+		logger := logging.CurrentLogger(req.Context())
+		logger.Infof("error encoding response: %v", err)
 	}
 }

--- a/util/logging/context.go
+++ b/util/logging/context.go
@@ -1,0 +1,15 @@
+package logging
+
+import "context"
+
+type contextKey int
+
+const loggerKey contextKey = 1
+
+func ContextWithLogger(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+func CurrentLogger(ctx context.Context) Logger {
+	return ctx.Value(loggerKey).(Logger)
+}

--- a/util/logging/logger.go
+++ b/util/logging/logger.go
@@ -1,0 +1,23 @@
+package logging
+
+import (
+	golog "log"
+)
+
+type Logger interface {
+	Infof(format string, v ...interface{})
+}
+
+type GoLogger struct {
+	Underlying *golog.Logger
+}
+
+func (l *GoLogger) Infof(format string, v ...interface{}) {
+	l.Underlying.Printf(format, v...)
+}
+
+func Default() Logger {
+	return &GoLogger{
+		Underlying: golog.Default(),
+	}
+}

--- a/util/logging/logger.go
+++ b/util/logging/logger.go
@@ -6,6 +6,7 @@ import (
 
 type Logger interface {
 	Infof(format string, v ...interface{})
+	Sublogger(prefix string) Logger
 }
 
 type GoLogger struct {
@@ -16,8 +17,31 @@ func (l *GoLogger) Infof(format string, v ...interface{}) {
 	l.Underlying.Printf(format, v...)
 }
 
+func (l *GoLogger) Sublogger(prefix string) Logger {
+	return &Sublogger{
+		Underlying: l,
+		Prefix:     prefix,
+	}
+}
+
 func Default() Logger {
 	return &GoLogger{
 		Underlying: golog.Default(),
+	}
+}
+
+type Sublogger struct {
+	Underlying Logger
+	Prefix     string
+}
+
+func (l *Sublogger) Infof(format string, v ...interface{}) {
+	l.Underlying.Infof(l.Prefix+": "+format, v...)
+}
+
+func (l *Sublogger) Sublogger(prefix string) Logger {
+	return &Sublogger{
+		Underlying: l,
+		Prefix:     l.Prefix + " " + prefix,
 	}
 }


### PR DESCRIPTION
There is increasing complexity and parallelism in the internals of things in support of Docker & I wanted to improve the logs from the exo server itself. I've done the minimum work here to make sure we always use an injected logger. As follow-up work, I'll start to add prefixes or other structured logging data, so that we can correlate messages for a particular request or apply or whatever.