### PR TITLE
Default scrollbars fix

### DIFF
--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -55,3 +55,22 @@ h1 {
     --bg-color: #061a29;
   }
 } */
+
+/* Avoid awful default scrollbars in most OS/Browsers, especially in horizontally scrolling text displays. */
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 4px;
+  background: rgba(96, 96, 96, 0.1);
+  margin: 4px;
+  position: relative;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(96, 96, 96, 0.33);
+  border-radius: 1px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(96, 96, 96, 0.67);
+}


### PR DESCRIPTION
This adds custom scrollbar styling in order to avoid the excessively large and ugly default scrollbars present in most OS+Browser combinations, in favor of a consistent style across all instances of the **exo** GUI.

Will also help with the new multi-panel layout.

---

Fixes this

![image](https://user-images.githubusercontent.com/51100181/128363854-af24b667-50dc-4e5a-b93f-f4f726b50b5a.png)

into this

![image](https://user-images.githubusercontent.com/51100181/128363726-f25d5fd2-76d4-4349-ade7-f0e281d3c92b.png)
