### PR TITLE
Filter logs

### DIFF
--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -3,11 +3,17 @@
   import { onMount, onDestroy, afterUpdate, beforeUpdate } from 'svelte';
   import { hasData, isUnresolved } from '../lib/api';
   import type { WorkspaceApi } from '../lib/api';
-  import { loadInitialLogs, logsStore, refreshLogs } from '../lib/logs/store';
+  import {
+    loadInitialLogs,
+    logsStore,
+    refreshLogs,
+    setFilterStr,
+  } from '../lib/logs/store';
   import type { WorkspaceState } from '../lib/logs/store';
   import { shortDate } from '../lib/time';
   import { processes } from '../lib/process/store';
   import FormattedLogMessage from './logs/FormattedLogMessage.svelte';
+  import debounce from '../lib/debounce';
 
   export let workspace: WorkspaceApi;
   export let workspaceId: string;
@@ -16,6 +22,7 @@
 
   let state: WorkspaceState = {
     cursor: null,
+    filterStr: null,
     events: { stage: 'success', data: [] },
   };
   const unsubscribeLogStore = logsStore.subscribe((workspaces) => {
@@ -81,6 +88,10 @@
       logViewport.scrollTop = logViewport.scrollHeight;
     }
   });
+
+  const setFilterStrDebounced = debounce((fitlerStr: string) => {
+    setFilterStr(workspaceId, workspace, fitlerStr);
+  }, 250);
 </script>
 
 <section>
@@ -99,6 +110,14 @@
         {/each}
       </div>
     </div>
+    <input
+      placeholder="Filter..."
+      value={state.filterStr || ''}
+      on:input={(e) => {
+        const text = e.currentTarget.value.trim();
+        setFilterStrDebounced(text);
+      }}
+    />
   {:else if isUnresolved(state.events)}
     <div>Loading logs...</div>
   {:else}

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -164,7 +164,7 @@
 
   td {
     padding: 0 0.3em;
-    white-space: pre;
+    vertical-align: text-top;
     color: #333333;
   }
 

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -86,19 +86,17 @@
 <section>
   <h1>Logs</h1>
   {#if hasData(state.events)}
-    <div class="log-table-overflow-wrapper">
-      <div class="log-table-container" bind:this={logViewport}>
-        <table>
-          {#each state.events.data as event (event.id)}
-            <tr class="log-entry" style={logStyleFromHash(event.log)}>
-              <td>{shortDate(event.timestamp)}</td>
-              <td>{friendlyName(event.log)}</td>
-              <td>
-                <FormattedLogMessage message={event.message} />
-              </td>
-            </tr>
-          {/each}
-        </table>
+    <div class="log-overflow-wrapper">
+      <div class="log-container" bind:this={logViewport}>
+        {#each state.events.data as event (event.id)}
+          <div class="log-entry" style={logStyleFromHash(event.log)}>
+            <div class="timestamp">{shortDate(event.timestamp)}</div>
+            <div class="log">{friendlyName(event.log)}</div>
+            <div class="message">
+              <FormattedLogMessage message={event.message} />
+            </div>
+          </div>
+        {/each}
       </div>
     </div>
   {:else if isUnresolved(state.events)}
@@ -117,58 +115,50 @@
     grid-template-rows: max-content 1fr;
   }
 
-  .log-table-overflow-wrapper {
+  .log-overflow-wrapper {
     overflow: hidden;
     border-radius: 4px;
     box-shadow: 0px 12px 16px -8px #00000033, 0px 0.25px 0px 1px #00000033;
   }
 
-  .log-table-container {
+  .log-container {
     width: 100%;
     height: 100%;
-    overflow-x: auto;
-    overflow-y: scroll;
-  }
-
-  table {
     font-family: 'Fira Code', monospace;
     font-weight: 450;
     font-size: 15px;
+    overflow-y: scroll;
   }
 
-  table,
-  tr,
-  td {
-    border: none;
-    border-collapse: collapse;
+  .log-entry {
+    display: flex;
   }
 
-  td {
+  .log-entry > div {
     padding: 0 0.3em;
-    white-space: pre;
     color: #333333;
   }
 
-  tr:hover td {
+  .log-entry:hover {
     background: #f3f3f3;
     color: #111111;
   }
 
-  td:nth-child(1) {
+  .timestamp {
     color: #999999;
   }
 
-  tr:hover td:nth-child(1) {
+  .log-entry:hover .timestamp {
     background: #eeeeee;
     color: #555555;
   }
 
-  td:nth-child(2) {
+  .log {
     background: var(--log-bg-color);
     color: var(--log-color);
   }
 
-  tr:hover td:nth-child(2) {
+  .log-entry:hover .log {
     background: var(--log-bg-hover-color);
   }
 </style>

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -97,17 +97,19 @@
 <section>
   <h1>Logs</h1>
   {#if hasData(state.events)}
-    <div class="log-overflow-wrapper">
-      <div class="log-container" bind:this={logViewport}>
-        {#each state.events.data as event (event.id)}
-          <div class="log-entry" style={logStyleFromHash(event.log)}>
-            <div class="timestamp">{shortDate(event.timestamp)}</div>
-            <div class="log">{friendlyName(event.log)}</div>
-            <div class="message">
-              <FormattedLogMessage message={event.message} />
-            </div>
-          </div>
-        {/each}
+    <div class="log-table-overflow-wrapper">
+      <div class="log-table-container" bind:this={logViewport}>
+        <table>
+          {#each state.events.data as event (event.id)}
+            <tr class="log-entry" style={logStyleFromHash(event.log)}>
+              <td>{shortDate(event.timestamp)}</td>
+              <td>{friendlyName(event.log)}</td>
+              <td>
+                <FormattedLogMessage message={event.message} />
+              </td>
+            </tr>
+          {/each}
+        </table>
       </div>
     </div>
     <input
@@ -134,50 +136,58 @@
     grid-template-rows: max-content 1fr;
   }
 
-  .log-overflow-wrapper {
+  .log-table-overflow-wrapper {
     overflow: hidden;
     border-radius: 4px;
     box-shadow: 0px 12px 16px -8px #00000033, 0px 0.25px 0px 1px #00000033;
   }
 
-  .log-container {
+  .log-table-container {
     width: 100%;
     height: 100%;
-    font-family: 'Fira Code', monospace;
-    font-weight: 450;
-    font-size: 15px;
+    overflow-x: auto;
     overflow-y: scroll;
   }
 
-  .log-entry {
-    display: flex;
+  table {
+    font-family: 'Fira Code', monospace;
+    font-weight: 450;
+    font-size: 15px;
   }
 
-  .log-entry > div {
+  table,
+  tr,
+  td {
+    border: none;
+    border-collapse: collapse;
+  }
+
+  td {
     padding: 0 0.3em;
+    white-space: pre;
     color: #333333;
   }
 
-  .log-entry:hover {
+  tr:hover td {
     background: #f3f3f3;
     color: #111111;
   }
 
-  .timestamp {
+  td:nth-child(1) {
     color: #999999;
   }
 
-  .log-entry:hover .timestamp {
+  tr:hover td:nth-child(1) {
     background: #eeeeee;
     color: #555555;
   }
 
-  .log {
+  td:nth-child(2) {
     background: var(--log-bg-color);
     color: var(--log-color);
   }
 
-  .log-entry:hover .log {
+  tr:hover td:nth-child(2) {
     background: var(--log-bg-hover-color);
   }
 </style>

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -89,8 +89,8 @@
     }
   });
 
-  const setFilterStrDebounced = debounce((fitlerStr: string) => {
-    setFilterStr(workspaceId, workspace, fitlerStr);
+  const setFilterStrDebounced = debounce((filterStr: string) => {
+    setFilterStr(workspaceId, workspace, filterStr);
   }, 250);
 </script>
 

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -203,6 +203,7 @@ export interface WorkspaceApi {
 
   getEvents(
     logs: string[],
+    fitlerStr: string | null,
     pagination?: PaginationParams,
   ): Promise<LogsResponse>;
 }
@@ -292,10 +293,12 @@ export const api = (() => {
 
       async getEvents(
         logs: string[],
+        filterStr: string | null,
         pagination?: PaginationParams,
       ): Promise<LogsResponse> {
         return (await invoke('get-events', {
           logs,
+          filterStr,
           ...pagination,
         })) as LogsResponse;
       },

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -203,7 +203,7 @@ export interface WorkspaceApi {
 
   getEvents(
     logs: string[],
-    fitlerStr: string | null,
+    filterStr: string | null,
     pagination?: PaginationParams,
   ): Promise<LogsResponse>;
 }

--- a/gui/src/lib/debounce.ts
+++ b/gui/src/lib/debounce.ts
@@ -1,0 +1,19 @@
+type VoidFunc<TArgs extends any[]> = (...args: TArgs) => void;
+
+export default function debounce<TArgs extends any[]>(
+  f: VoidFunc<TArgs>,
+  delayMs: number,
+): VoidFunc<TArgs> {
+  let timer: number | null = null;
+  let lastArgs: TArgs | null = null;
+
+  return (...args: TArgs) => {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+    }
+    timer = window.setTimeout(() => {
+      f(...(lastArgs as TArgs));
+    }, delayMs);
+    lastArgs = args;
+  };
+}

--- a/gui/src/lib/logs/store.ts
+++ b/gui/src/lib/logs/store.ts
@@ -97,8 +97,16 @@ export const fetchLogs = async (
 export const refreshLogs = (workspaceId: string, workspace: WorkspaceApi) =>
   fetchLogs(workspaceId, workspace, { next: 100 });
 
-export const loadInitialLogs = (workspaceId: string, workspace: WorkspaceApi) =>
-  fetchLogs(workspaceId, workspace, { prev: 100 });
+export const loadInitialLogs = (workspaceId: string, workspace: WorkspaceApi) => {
+  logsStore.update((state) => ({
+    ...state,
+    [workspaceId]: {
+      cursor: null,
+      events: pendingRequest(),
+    }
+  }));
+  return fetchLogs(workspaceId, workspace, { prev: 100 });
+}
 
 export const resetLogs = (workspaceId: string) => {
   logsStore.update((state) => {

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -176,10 +176,11 @@ type DescribeLogsOutput struct {
 }
 
 type GetEventsInput struct {
-	Logs   []string `json:"logs"`
-	Cursor *string  `json:"cursor"`
-	Prev   *int     `json:"prev"`
-	Next   *int     `json:"next"`
+	Logs      []string `json:"logs"`
+	Cursor    *string  `json:"cursor"`
+	FilterStr *string  `json:"filterStr"`
+	Prev      *int     `json:"prev"`
+	Next      *int     `json:"next"`
 }
 
 type GetEventsOutput struct {

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -109,6 +109,7 @@ interface "workspace" {
     input "logs" "[]string" {}
 
     input "cursor" "*string" {}
+    input "filterStr" "*string" {}
     input "prev" "*int" {}
     input "next" "*int" {}
 

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -516,10 +516,11 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 
 	collector := log.CurrentLogCollector(ctx)
 	collectorOutput, err := collector.GetEvents(ctx, &logd.GetEventsInput{
-		Logs:   logStreams,
-		Cursor: input.Cursor,
-		Prev:   input.Prev,
-		Next:   input.Next,
+		Logs:      logStreams,
+		Cursor:    input.Cursor,
+		FilterStr: input.FilterStr,
+		Prev:      input.Prev,
+		Next:      input.Next,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/logd/api/collector.go
+++ b/internal/logd/api/collector.go
@@ -44,10 +44,11 @@ type AddEventOutput struct {
 }
 
 type GetEventsInput struct {
-	Logs   []string `json:"logs"`
-	Cursor *string  `json:"cursor"`
-	Prev   *int     `json:"prev"`
-	Next   *int     `json:"next"`
+	Logs      []string `json:"logs"`
+	Cursor    *string  `json:"cursor"`
+	FilterStr *string  `json:"filterStr"`
+	Prev      *int     `json:"prev"`
+	Next      *int     `json:"next"`
 }
 
 type GetEventsOutput struct {

--- a/internal/logd/api/collector.josh.hcl
+++ b/internal/logd/api/collector.josh.hcl
@@ -25,6 +25,7 @@ interface "log-collector" {
     input "logs" "[]string" {}
 
     input "cursor" "*string" {}
+    input "filterStr" "*string" {}
     input "prev" "*int" {}
     input "next" "*int" {}
 

--- a/internal/logd/server/collector.go
+++ b/internal/logd/server/collector.go
@@ -143,7 +143,7 @@ func (lc *LogCollector) GetEvents(ctx context.Context, input *api.GetEventsInput
 	for _, logName := range input.Logs {
 		log := lc.Store.GetLog(logName)
 
-		logEventsWithCursors, err := log.GetEvents(ctx, cursor, limit, direction)
+		logEventsWithCursors, err := log.GetEvents(ctx, cursor, limit, direction, input.FilterStr)
 		if err != nil {
 			return nil, fmt.Errorf("getting %q events: %w", logName, err)
 		}

--- a/internal/logd/store/api.go
+++ b/internal/logd/store/api.go
@@ -19,7 +19,9 @@ type Log interface {
 
 	// GetEvents returns a page of events along with cursors for moving forward or backward in the result set.
 	// If `cursor` is nil, returns the most recent page of events, which is useful for the UI's default tailing behaviour.
-	GetEvents(ctx context.Context, cursor *Cursor, limit int, direction Direction) ([]EventWithCursors, error)
+	// `filterStr` is an optional string that will cause only those messages which contain it as a substring to be
+	// returned. This is a hack until we can add a more robust storage engine.
+	GetEvents(ctx context.Context, cursor *Cursor, limit int, direction Direction, filterStr *string) ([]EventWithCursors, error)
 
 	GetLastCursor(context.Context) (*Cursor, error)
 	GetLastEvent(context.Context) (*api.Event, error)


### PR DESCRIPTION
https://www.loom.com/share/d984903afb9343e38d5322c69a92f1e1

This is just hacked in for now because my plan is to revisit the storage engine and general state management for logs right after we get the Docker Compose release wrapped up.

Also addresses:
- Wrapping text in long log lines
- GUI breakage when re-mounting the log viewer.

Fixes #94 