### PR TITLE
job watching for start, stop, restart (and refactored for refresh too)

### DIFF
--- a/cmd/exo/control.go
+++ b/cmd/exo/control.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+
+	"github.com/deref/exo/internal/core/api"
+)
+
+type controlFunc func(ctx context.Context, ws api.Workspace, refs []string) (jobID string, err error)
+
+func controlComponents(args []string, f controlFunc) error {
+	ctx := newContext()
+	ensureDaemon()
+	cl := newClient()
+	kernel := cl.Kernel()
+	workspace := requireWorkspace(ctx, cl)
+
+	var jobID string
+	var err error
+	if len(args) == 0 {
+		jobID, err = f(ctx, workspace, nil)
+	} else {
+		jobID, err = f(ctx, workspace, args)
+	}
+	if err != nil {
+		return err
+	}
+
+	return watchJob(ctx, kernel, jobID)
+}

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -19,18 +19,21 @@ type StartInput struct {
 }
 
 type StartOutput struct {
+	JobID string `json:"jobId"`
 }
 
 type StopInput struct {
 }
 
 type StopOutput struct {
+	JobID string `json:"jobId"`
 }
 
 type RestartInput struct {
 }
 
 type RestartOutput struct {
+	JobID string `json:"jobId"`
 }
 
 func BuildProcessMux(b *josh.MuxBuilder, factory func(req *http.Request) Process) {
@@ -70,9 +73,9 @@ type Workspace interface {
 	DescribeLogs(context.Context, *DescribeLogsInput) (*DescribeLogsOutput, error)
 	// Returns pages of log events for some set of logs. If `cursor` is specified, standard pagination behavior is used. Otherwise the cursor is assumed to represent the current tail of the log.
 	GetEvents(context.Context, *GetEventsInput) (*GetEventsOutput, error)
-	StartComponent(context.Context, *StartComponentInput) (*StartComponentOutput, error)
-	StopComponent(context.Context, *StopComponentInput) (*StopComponentOutput, error)
-	RestartComponent(context.Context, *RestartComponentInput) (*RestartComponentOutput, error)
+	StartComponents(context.Context, *StartComponentsInput) (*StartComponentsOutput, error)
+	StopComponents(context.Context, *StopComponentsInput) (*StopComponentsOutput, error)
+	RestartComponents(context.Context, *RestartComponentsInput) (*RestartComponentsOutput, error)
 	DescribeProcesses(context.Context, *DescribeProcessesInput) (*DescribeProcessesOutput, error)
 	DescribeVolumes(context.Context, *DescribeVolumesInput) (*DescribeVolumesOutput, error)
 	DescribeNetworks(context.Context, *DescribeNetworksInput) (*DescribeNetworksOutput, error)
@@ -189,25 +192,28 @@ type GetEventsOutput struct {
 	NextCursor string  `json:"nextCursor"`
 }
 
-type StartComponentInput struct {
-	Ref string `json:"ref"`
+type StartComponentsInput struct {
+	Refs []string `json:"refs"`
 }
 
-type StartComponentOutput struct {
+type StartComponentsOutput struct {
+	JobID string `json:"jobId"`
 }
 
-type StopComponentInput struct {
-	Ref string `json:"ref"`
+type StopComponentsInput struct {
+	Refs []string `json:"refs"`
 }
 
-type StopComponentOutput struct {
+type StopComponentsOutput struct {
+	JobID string `json:"jobId"`
 }
 
-type RestartComponentInput struct {
-	Ref string `json:"ref"`
+type RestartComponentsInput struct {
+	Refs []string `json:"refs"`
 }
 
-type RestartComponentOutput struct {
+type RestartComponentsOutput struct {
+	JobID string `json:"jobId"`
 }
 
 type DescribeProcessesInput struct {
@@ -277,14 +283,14 @@ func BuildWorkspaceMux(b *josh.MuxBuilder, factory func(req *http.Request) Works
 	b.AddMethod("get-events", func(req *http.Request) interface{} {
 		return factory(req).GetEvents
 	})
-	b.AddMethod("start-component", func(req *http.Request) interface{} {
-		return factory(req).StartComponent
+	b.AddMethod("start-components", func(req *http.Request) interface{} {
+		return factory(req).StartComponents
 	})
-	b.AddMethod("stop-component", func(req *http.Request) interface{} {
-		return factory(req).StopComponent
+	b.AddMethod("stop-components", func(req *http.Request) interface{} {
+		return factory(req).StopComponents
 	})
-	b.AddMethod("restart-component", func(req *http.Request) interface{} {
-		return factory(req).RestartComponent
+	b.AddMethod("restart-components", func(req *http.Request) interface{} {
+		return factory(req).RestartComponents
 	})
 	b.AddMethod("describe-processes", func(req *http.Request) interface{} {
 		return factory(req).DescribeProcesses

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -1,9 +1,16 @@
 # XXX This is only in the same file as workspace because workspace refers to
 # it and the JOSH loader does not yet properly handle multi-file packages.
 interface "process" {
-  method "start" {}
-  method "stop" {}
-  method "restart" {} # TODO: Optional method?
+  method "start" {
+    output "job-id" "string" {}
+  }
+  method "stop" {
+    output "job-id" "string" {}
+  }
+  # TODO: Optional method?
+  method "restart" {
+    output "job-id" "string" {}
+  }
 }
 
 interface "workspace" {
@@ -118,16 +125,19 @@ interface "workspace" {
     output "nextCursor" "string" {}
   }
 
-  method "start-component" {
-    input "ref" "string" {}
+  method "start-components" {
+    input "refs" "[]string" {}
+    output "job-id" "string" {}
   }
 
-  method "stop-component" {
-    input "ref" "string" {}
+  method "stop-components" {
+    input "refs" "[]string" {}
+    output "job-id" "string" {}
   }
 
-  method "restart-component" {
-    input "ref" "string" {}
+  method "restart-components" {
+    input "refs" "[]string" {}
+    output "job-id" "string" {}
   }
 
   method "describe-processes" {

--- a/internal/core/client/workspace.go
+++ b/internal/core/client/workspace.go
@@ -123,18 +123,18 @@ func (c *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (o
 	return
 }
 
-func (c *Workspace) StartComponent(ctx context.Context, input *api.StartComponentInput) (output *api.StartComponentOutput, err error) {
-	err = c.client.Invoke(ctx, "start-component", input, &output)
+func (c *Workspace) StartComponents(ctx context.Context, input *api.StartComponentsInput) (output *api.StartComponentsOutput, err error) {
+	err = c.client.Invoke(ctx, "start-components", input, &output)
 	return
 }
 
-func (c *Workspace) StopComponent(ctx context.Context, input *api.StopComponentInput) (output *api.StopComponentOutput, err error) {
-	err = c.client.Invoke(ctx, "stop-component", input, &output)
+func (c *Workspace) StopComponents(ctx context.Context, input *api.StopComponentsInput) (output *api.StopComponentsOutput, err error) {
+	err = c.client.Invoke(ctx, "stop-components", input, &output)
 	return
 }
 
-func (c *Workspace) RestartComponent(ctx context.Context, input *api.RestartComponentInput) (output *api.RestartComponentOutput, err error) {
-	err = c.client.Invoke(ctx, "restart-component", input, &output)
+func (c *Workspace) RestartComponents(ctx context.Context, input *api.RestartComponentsInput) (output *api.RestartComponentsOutput, err error) {
+	err = c.client.Invoke(ctx, "restart-components", input, &output)
 	return
 }
 

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -327,7 +327,7 @@ func (ws *Workspace) RefreshComponents(ctx context.Context, input *api.RefreshCo
 		return nil, fmt.Errorf("describing components: %w", err)
 	}
 
-	refreshTask := ws.TaskTracker.StartTask(ctx, "refresh")
+	refreshTask := ws.TaskTracker.StartTask(ctx, "refreshing")
 	go func() {
 		defer refreshTask.Finish()
 		for _, component := range describeOutput.Components {
@@ -542,111 +542,90 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 }
 
 func (ws *Workspace) Start(ctx context.Context, input *api.StartInput) (*api.StartOutput, error) {
-	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
+	jobID, err := ws.controlEachProcess(ctx, "starting", func(process api.Process) error {
 		_, err := process.Start(ctx, &api.StartInput{})
 		return err
-	}); err != nil {
-		return nil, err
-	}
-	return &api.StartOutput{}, nil
-}
-
-func (ws *Workspace) StartComponent(ctx context.Context, input *api.StartComponentInput) (*api.StartComponentOutput, error) {
-	id, err := ws.resolveRef(ctx, input.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("resolving ref: %w", err)
-	}
-
-	components, err := ws.DescribeComponents(ctx, &api.DescribeComponentsInput{
-		IDs: []string{id},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("fetching component state: %w", err)
-	}
-	if len(components.Components) != 1 {
-		return nil, fmt.Errorf("no state for component: %s", id)
-	}
-	component := components.Components[0]
-
-	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Start(ctx, &api.StartInput{})
-		return err
-	}); err != nil {
 		return nil, err
 	}
-	return &api.StartComponentOutput{}, nil
+	return &api.StartOutput{
+		JobID: jobID,
+	}, nil
+}
+
+func (ws *Workspace) StartComponents(ctx context.Context, input *api.StartComponentsInput) (*api.StartComponentsOutput, error) {
+	filter := componentFilter{
+		Refs: input.Refs,
+	}
+	jobID, err := ws.controlEachComponent(ctx, "starting", filter, func(process api.Process) error {
+		_, err := process.Start(ctx, &api.StartInput{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &api.StartComponentsOutput{
+		JobID: jobID,
+	}, nil
 }
 
 func (ws *Workspace) Stop(ctx context.Context, input *api.StopInput) (*api.StopOutput, error) {
-	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
+	jobID, err := ws.controlEachProcess(ctx, "stopping", func(process api.Process) error {
 		_, err := process.Stop(ctx, &api.StopInput{})
 		return err
-	}); err != nil {
-		return nil, err
-	}
-	return &api.StopOutput{}, nil
-}
-
-func (ws *Workspace) StopComponent(ctx context.Context, input *api.StopComponentInput) (*api.StopComponentOutput, error) {
-	id, err := ws.resolveRef(ctx, input.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("resolving ref: %w", err)
-	}
-
-	components, err := ws.DescribeComponents(ctx, &api.DescribeComponentsInput{
-		IDs: []string{id},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("fetching component state: %w", err)
-	}
-	if len(components.Components) != 1 {
-		return nil, fmt.Errorf("no state for component: %s", id)
-	}
-	component := components.Components[0]
-
-	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Stop(ctx, &api.StopInput{})
-		return err
-	}); err != nil {
 		return nil, err
 	}
-	return &api.StopComponentOutput{}, nil
+	return &api.StopOutput{
+		JobID: jobID,
+	}, nil
+}
+
+func (ws *Workspace) StopComponents(ctx context.Context, input *api.StopComponentsInput) (*api.StopComponentsOutput, error) {
+	filter := componentFilter{
+		Refs: input.Refs,
+	}
+	jobID, err := ws.controlEachComponent(ctx, "stopping", filter, func(process api.Process) error {
+		_, err := process.Stop(ctx, &api.StopInput{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &api.StopComponentsOutput{
+		JobID: jobID,
+	}, nil
 }
 
 func (ws *Workspace) Restart(ctx context.Context, input *api.RestartInput) (*api.RestartOutput, error) {
-	if err := ws.controlEachProcess(ctx, func(process api.Process) error {
+	jobID, err := ws.controlEachProcess(ctx, "restarting", func(process api.Process) error {
 		_, err := process.Restart(ctx, &api.RestartInput{})
 		return err
-	}); err != nil {
-		return nil, err
-	}
-	return &api.RestartOutput{}, nil
-}
-
-func (ws *Workspace) RestartComponent(ctx context.Context, input *api.RestartComponentInput) (*api.RestartComponentOutput, error) {
-	id, err := ws.resolveRef(ctx, input.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("resolving ref: %w", err)
-	}
-
-	components, err := ws.DescribeComponents(ctx, &api.DescribeComponentsInput{
-		IDs: []string{id},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("fetching component state: %w", err)
-	}
-	if len(components.Components) != 1 {
-		return nil, fmt.Errorf("no state for component: %s", id)
-	}
-	component := components.Components[0]
-
-	if err := ws.control(ctx, component, func(process api.Process) error {
-		_, err := process.Restart(ctx, &api.RestartInput{})
-		return err
-	}); err != nil {
 		return nil, err
 	}
-	return &api.RestartComponentOutput{}, nil
+	return &api.RestartOutput{
+		JobID: jobID,
+	}, nil
+}
+
+func (ws *Workspace) RestartComponents(ctx context.Context, input *api.RestartComponentsInput) (*api.RestartComponentsOutput, error) {
+	filter := componentFilter{
+		Refs: input.Refs,
+	}
+	jobID, err := ws.controlEachComponent(ctx, "restart", filter, func(process api.Process) error {
+		_, err := process.Start(ctx, &api.StartInput{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &api.RestartComponentsOutput{
+		JobID: jobID,
+	}, nil
 }
 
 // TODO: Filter by interface, not concrete type.
@@ -791,19 +770,46 @@ func (ws *Workspace) DescribeNetworks(ctx context.Context, input *api.DescribeNe
 	return &output, nil
 }
 
-func (ws *Workspace) controlEachProcess(ctx context.Context, f interface{}) error {
-	components, err := ws.DescribeComponents(ctx, &api.DescribeComponentsInput{
-		Types: processTypes,
-	})
-	if err != nil {
-		return fmt.Errorf("describing components: %w", err)
+type componentFilter struct {
+	Refs  []string
+	Types []string
+}
+
+func (ws *Workspace) controlEachComponent(ctx context.Context, label string, filter componentFilter, f interface{}) (jobID string, err error) {
+	describe := &api.DescribeComponentsInput{
+		Types: filter.Types,
 	}
-	for _, component := range components.Components {
-		if err := ws.control(ctx, component, f); err != nil {
-			return fmt.Errorf("controlling %q: %w", component.ID, err)
+
+	if filter.Refs != nil {
+		ids, err := ws.resolveRefs(ctx, filter.Refs)
+		if err != nil {
+			return "", fmt.Errorf("resolving refs: %w", err)
 		}
+		describe.IDs = ids
 	}
-	return nil
+
+	components, err := ws.DescribeComponents(ctx, describe)
+	if err != nil {
+		return "", fmt.Errorf("describing components: %w", err)
+	}
+
+	job := ws.TaskTracker.StartTask(ctx, label)
+	go func() {
+		defer job.Finish()
+		for _, component := range components.Components {
+			job.Go(component.Name, func(*task.Task) error {
+				return ws.control(ctx, component, f)
+			})
+		}
+	}()
+	return job.JobID(), nil
+}
+
+func (ws *Workspace) controlEachProcess(ctx context.Context, label string, f interface{}) (jobID string, err error) {
+	filter := componentFilter{
+		Types: processTypes,
+	}
+	return ws.controlEachComponent(ctx, label, filter, f)
 }
 
 func (ws *Workspace) control(ctx context.Context, desc api.ComponentDescription, f interface{}) error {

--- a/internal/providers/unix/components/process/component.go
+++ b/internal/providers/unix/components/process/component.go
@@ -25,3 +25,7 @@ type State struct {
 	// Program string `json:"program"`
 	FullEnvironment map[string]string `json:"fullEnvironment"`
 }
+
+func (state *State) clear() {
+	*state = State{}
+}

--- a/internal/providers/unix/components/process/lifecycle.go
+++ b/internal/providers/unix/components/process/lifecycle.go
@@ -40,8 +40,8 @@ func (p *Process) Refresh(ctx context.Context, input *core.RefreshInput) (*core.
 }
 
 func (p *Process) refresh() {
-	if !osutil.IsValidPid(p.Pid) {
-		p.Pid = 0
+	if !osutil.IsValidPid(p.SupervisorPid) {
+		p.State.clear()
 	}
 }
 


### PR DESCRIPTION
Various related changes here:

- more operations are now bulk
- common code paths are used now for start, stop, restart, and refresh both on server and in CLI
- CLI now does `watchJob` to support progress monitoring for these operations (critical for docker containers, where there is presently no feedback, but will be soon)