### PR TITLE
Improve filter input styling

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -4784,6 +4784,16 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
+      }
+    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -1,3 +1,11 @@
+/* Default global styles for component properties that can be overridden with `style-props` */
+
+:root {
+  --input-width: 300px;
+}
+
+/* Theme color variables */
+
 :root {
   --text-color: #061a29;
   --bg-color: #fff;

--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -99,16 +99,13 @@
     padding: 4px 6px;
     height: 20px;
     align-items: center;
+    font-size: 12px;
     background: #eeeeee;
+    color: #555555;
   }
 
   footer.devmode {
-    background: rgb(21, 3, 33);
-    background: linear-gradient(
-      158deg,
-      rgba(21, 3, 33, 0.8403069846102503) 5%,
-      rgba(127, 85, 183, 1) 43%,
-      rgba(144, 218, 245, 1) 100%
-    );
+    background: #007bd4;
+    color: #ffffff;
   }
 </style>

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -13,6 +13,7 @@
   import { shortDate } from '../lib/time';
   import { processes } from '../lib/process/store';
   import FormattedLogMessage from './logs/FormattedLogMessage.svelte';
+  import Textbox from './Textbox.svelte';
   import debounce from '../lib/debounce';
 
   export let workspace: WorkspaceApi;
@@ -112,13 +113,14 @@
         </table>
       </div>
     </div>
-    <input
+    <Textbox
       placeholder="Filter..."
       value={state.filterStr || ''}
       on:input={(e) => {
-        const text = e.currentTarget.value.trim();
+        const text = e.currentTarget?.value.trim();
         setFilterStrDebounced(text);
       }}
+      --input-width="100%"
     />
   {:else if isUnresolved(state.events)}
     <div>Loading logs...</div>
@@ -128,16 +130,6 @@
 </section>
 
 <style>
-  input {
-    border: none;
-    border-radius: 6px;
-    padding: 12px 18px;
-    margin-top: 18px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.1) inset,
-      0 0.4px 0 0.8px rgba(0, 0, 0, 0.1) inset;
-  }
-
   section {
     overflow: hidden;
     padding: 1px;
@@ -150,6 +142,7 @@
     overflow: hidden;
     border-radius: 4px;
     box-shadow: 0px 12px 16px -8px #00000033, 0px 0.25px 0px 1px #00000033;
+    margin-bottom: 18px;
   }
 
   .log-table-container {

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -128,6 +128,16 @@
 </section>
 
 <style>
+  input {
+    border: none;
+    border-radius: 6px;
+    padding: 12px 18px;
+    margin-top: 18px;
+    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
+      0 6px 9px -4px rgba(0, 0, 0, 0.1) inset,
+      0 0.4px 0 0.8px rgba(0, 0, 0, 0.1) inset;
+  }
+
   section {
     overflow: hidden;
     padding: 1px;

--- a/gui/src/components/Textbox.svelte
+++ b/gui/src/components/Textbox.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   export let id: string | undefined = undefined;
   export let name: string | undefined = undefined;
+  export let placeholder: string | undefined = undefined;
 
   export let value: string;
 </script>
 
-<input {id} bind:value {name} on:blur on:focus on:input />
+<input {id} bind:value {name} {placeholder} on:blur on:focus on:input />
 
 <style>
   input {
@@ -15,6 +16,6 @@
     box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
       0 6px 9px -4px rgba(0, 0, 0, 0.1) inset,
       0 0.4px 0 0.8px rgba(0, 0, 0, 0.1) inset;
-    width: 300px;
+    width: var(--input-width);
   }
 </style>

--- a/gui/src/components/VersionInfo.svelte
+++ b/gui/src/components/VersionInfo.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { api } from '../lib/api';
   import Button from './Button.svelte';
-import ErrorLabel from './ErrorLabel.svelte';
   import Spinner from './mono/spinner.svelte';
 
   let installedVersion: string | null = null;
@@ -52,22 +51,7 @@ import ErrorLabel from './ErrorLabel.svelte';
     </Button>
   {/if}
   {#if import.meta.env.MODE === 'development'}
-    <span class="callout">DEV MODE</span>
+    &nbsp;
+    <strong>DEV MODE</strong>
   {/if}
 </section>
-
-<style>
-  section {
-    font-size: 12px;
-    color: #666;
-  }
-
-  .callout {
-    background-color: red;
-    color: white;
-    padding: 4px;
-    display: inline-block;
-    border-radius: 5px;
-    font-weight: 700;
-  }
-</style>


### PR DESCRIPTION
Adds similar styling to the log viewer filter input as the new process form text inputs have, as an improvement over the (inconsistent) browser defaults.

![image](https://user-images.githubusercontent.com/51100181/128789447-aece264c-241e-42be-a2a1-b849dbc77245.png)

This uses Svelte's `--style-props` to allow overriding of the default `300px` `<Textbox />` input width without complicating the code for the actual components.

---

- This also simplifies the styling for the dev footer (note that the footer is going away / being replaced somewhere else in ~1 day or so as we swap to a left-sidebar-only layout with no global footer or header)

![image](https://user-images.githubusercontent.com/51100181/128789422-7d69b4aa-bed3-4fbe-b41a-bce3042ed1f8.png)
