### PR TITLE
Use localhost for syslog address

### DIFF
--- a/internal/providers/docker/components/container/lifecycle.go
+++ b/internal/providers/docker/components/container/lifecycle.go
@@ -79,7 +79,7 @@ func (c *Container) create(ctx context.Context) error {
 		// syslog service.
 		logCfg.Type = "syslog"
 		logCfg.Config = map[string]string{
-			"syslog-address":  fmt.Sprintf("udp://host.docker.internal:%d", c.SyslogPort),
+			"syslog-address":  fmt.Sprintf("udp://localhost:%d", c.SyslogPort),
 			"syslog-facility": "1", // "user-level messages"
 			"tag":             c.ComponentID,
 			"syslog-format":   "rfc5424micro",


### PR DESCRIPTION
I spent ages trying to debug DNS resolution in the container but I realised that the issue appears to be that the docker daemon on the host is actually handling syslog forwarding so we just need to use "localhost".

Could someone on a MacOS/Windows environment confirm this works?

Fixes #110 