### PR TITLE
Add telemetry around operation execution

### DIFF
--- a/cmd/exo/root.go
+++ b/cmd/exo/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/deref/exo/internal/config"
+	"github.com/deref/exo/internal/telemetry"
 	"github.com/deref/exo/internal/util/cmdutil"
 	"github.com/deref/exo/internal/util/logging"
 	"github.com/spf13/cobra"
@@ -27,8 +28,12 @@ For more information, see https://exo.deref.io`,
 
 func newContext() context.Context {
 	ctx := context.Background()
+
 	logger := logging.Default()
 	ctx = logging.ContextWithLogger(ctx, logger)
+
+	tel := telemetry.New(ctx, &cfg.Telemetry)
+	ctx = telemetry.ContextWithTelemetry(ctx, tel)
 
 	return ctx
 }

--- a/cmd/exo/upgrade.go
+++ b/cmd/exo/upgrade.go
@@ -20,7 +20,8 @@ var upgradeCmd = &cobra.Command{
 	Long:  `Upgrade exo to the latest version.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tel := telemetry.New(&cfg.Telemetry)
+		ctx := newContext()
+		tel := telemetry.New(ctx, &cfg.Telemetry)
 		if !tel.IsEnabled() {
 			fmt.Println("Cannot check current version - telemetry disabled.")
 			if upgrade.IsManaged {
@@ -32,7 +33,7 @@ var upgradeCmd = &cobra.Command{
 			return nil
 		}
 		current := exo.Version
-		latest, err := tel.LatestVersion()
+		latest, err := tel.LatestVersion(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/exo/upgrade.go
+++ b/cmd/exo/upgrade.go
@@ -21,7 +21,7 @@ var upgradeCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		tel := telemetry.New(ctx, &cfg.Telemetry)
+		tel := telemetry.FromContext(ctx)
 		if !tel.IsEnabled() {
 			fmt.Println("Cannot check current version - telemetry disabled.")
 			if upgrade.IsManaged {

--- a/cmd/exop/main.go
+++ b/cmd/exop/main.go
@@ -25,12 +25,15 @@ import (
 func main() {
 	ctx := context.Background()
 
-	logger := logging.Default()
-	ctx = logging.ContextWithLogger(ctx, logger)
-
 	cfg := &config.Config{}
 	config.MustLoadDefault(cfg)
 	paths := cmdutil.MustMakeDirectories(cfg)
+
+	logger := logging.Default()
+	ctx = logging.ContextWithLogger(ctx, logger)
+
+	tel := telemetry.New(ctx, &cfg.Telemetry)
+	ctx = telemetry.ContextWithTelemetry(ctx, tel)
 
 	statePath := filepath.Join(paths.VarDir, "state.json")
 	store := statefile.New(statePath)
@@ -48,7 +51,6 @@ func main() {
 	serverCfg := &server.Config{
 		VarDir:      paths.VarDir,
 		Store:       store,
-		Telemetry:   telemetry.New(ctx, &cfg.Telemetry),
 		Logger:      logger,
 		SyslogPort:  cfg.Log.SyslogPort,
 		Docker:      dockerClient,

--- a/cmd/exop/main.go
+++ b/cmd/exop/main.go
@@ -48,7 +48,7 @@ func main() {
 	serverCfg := &server.Config{
 		VarDir:      paths.VarDir,
 		Store:       store,
-		Telemetry:   telemetry.New(&cfg.Telemetry),
+		Telemetry:   telemetry.New(ctx, &cfg.Telemetry),
 		Logger:      logger,
 		SyslogPort:  cfg.Log.SyslogPort,
 		Docker:      dockerClient,

--- a/cmd/logd/main.go
+++ b/cmd/logd/main.go
@@ -29,6 +29,11 @@ func main() {
 	logger := logging.Default()
 	ctx = logging.ContextWithLogger(ctx, logger)
 
+	tel := telemetry.New(ctx, &config.TelemetryConfig{
+		Disable: true,
+	})
+	ctx = telemetry.ContextWithTelemetry(ctx, tel)
+
 	ctx, done := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer done()
 
@@ -68,11 +73,7 @@ func main() {
 	}
 	fmt.Println("listening at", addr)
 
-	tel := telemetry.New(ctx, &config.TelemetryConfig{
-		Disable: true,
-	})
-
-	muxb := josh.NewMuxBuilder(tel, "/")
+	muxb := josh.NewMuxBuilder("/")
 	api.BuildLogCollectorMux(muxb, func(req *http.Request) api.LogCollector {
 		return &logd.LogCollector
 	})

--- a/cmd/logd/main.go
+++ b/cmd/logd/main.go
@@ -18,6 +18,7 @@ import (
 	josh "github.com/deref/exo/internal/josh/server"
 	"github.com/deref/exo/internal/logd"
 	"github.com/deref/exo/internal/logd/api"
+	"github.com/deref/exo/internal/telemetry"
 	"github.com/deref/exo/internal/util/cmdutil"
 	"github.com/deref/exo/internal/util/logging"
 )
@@ -67,7 +68,11 @@ func main() {
 	}
 	fmt.Println("listening at", addr)
 
-	muxb := josh.NewMuxBuilder("/")
+	tel := telemetry.New(ctx, &config.TelemetryConfig{
+		Disable: true,
+	})
+
+	muxb := josh.NewMuxBuilder(tel, "/")
 	api.BuildLogCollectorMux(muxb, func(req *http.Request) api.LogCollector {
 		return &logd.LogCollector
 	})

--- a/cmd/logp/main.go
+++ b/cmd/logp/main.go
@@ -13,6 +13,7 @@ import (
 	josh "github.com/deref/exo/internal/josh/server"
 	"github.com/deref/exo/internal/logd"
 	"github.com/deref/exo/internal/logd/api"
+	"github.com/deref/exo/internal/telemetry"
 	"github.com/deref/exo/internal/util/cmdutil"
 	"github.com/deref/exo/internal/util/logging"
 	"github.com/deref/pier"
@@ -43,7 +44,11 @@ func main() {
 		}()
 	}
 
-	muxb := josh.NewMuxBuilder("/")
+	tel := telemetry.New(ctx, &config.TelemetryConfig{
+		Disable: true,
+	})
+
+	muxb := josh.NewMuxBuilder(tel, "/")
 	api.BuildLogCollectorMux(muxb, func(req *http.Request) api.LogCollector {
 		return &logd.LogCollector
 	})

--- a/cmd/logp/main.go
+++ b/cmd/logp/main.go
@@ -28,6 +28,10 @@ func main() {
 	config.MustLoadDefault(cfg)
 	paths := cmdutil.MustMakeDirectories(cfg)
 
+	ctx = telemetry.ContextWithTelemetry(ctx, telemetry.New(ctx, &config.TelemetryConfig{
+		Disable: true,
+	}))
+
 	logd := &logd.Service{
 		VarDir:     paths.VarDir,
 		SyslogPort: cfg.Log.SyslogPort,
@@ -44,11 +48,7 @@ func main() {
 		}()
 	}
 
-	tel := telemetry.New(ctx, &config.TelemetryConfig{
-		Disable: true,
-	})
-
-	muxb := josh.NewMuxBuilder(tel, "/")
+	muxb := josh.NewMuxBuilder("/")
 	api.BuildLogCollectorMux(muxb, func(req *http.Request) api.LogCollector {
 		return &logd.LogCollector
 	})

--- a/cmd/watch/main.go
+++ b/cmd/watch/main.go
@@ -161,7 +161,7 @@ func main() {
 				if child != nil {
 					gracefullyShutdown(childPgid, syscall.SIGTERM)
 				}
-				cmdutil.Fatalf("watching files: %w", err)
+				cmdutil.Fatalf("watching files: %v", err)
 			}
 		}
 	}()

--- a/internal/core/server/handler.go
+++ b/internal/core/server/handler.go
@@ -8,7 +8,6 @@ import (
 	josh "github.com/deref/exo/internal/josh/server"
 	"github.com/deref/exo/internal/task"
 	taskapi "github.com/deref/exo/internal/task/api"
-	"github.com/deref/exo/internal/telemetry"
 	"github.com/deref/exo/internal/util/logging"
 	docker "github.com/docker/docker/client"
 )
@@ -16,7 +15,6 @@ import (
 type Config struct {
 	VarDir      string
 	Store       state.Store
-	Telemetry   telemetry.Telemetry
 	SyslogPort  uint
 	Docker      *docker.Client
 	Logger      logging.Logger
@@ -24,14 +22,13 @@ type Config struct {
 }
 
 func BuildRootMux(prefix string, cfg *Config) *http.ServeMux {
-	b := josh.NewMuxBuilder(cfg.Telemetry, prefix)
+	b := josh.NewMuxBuilder(prefix)
 
 	endKernel := b.Begin("kernel")
 	api.BuildKernelMux(b, func(req *http.Request) api.Kernel {
 		return &Kernel{
 			VarDir:      cfg.VarDir,
 			Store:       cfg.Store,
-			Telemetry:   cfg.Telemetry,
 			TaskTracker: cfg.TaskTracker,
 		}
 	})

--- a/internal/core/server/handler.go
+++ b/internal/core/server/handler.go
@@ -24,7 +24,7 @@ type Config struct {
 }
 
 func BuildRootMux(prefix string, cfg *Config) *http.ServeMux {
-	b := josh.NewMuxBuilder(prefix)
+	b := josh.NewMuxBuilder(cfg.Telemetry, prefix)
 
 	endKernel := b.Begin("kernel")
 	api.BuildKernelMux(b, func(req *http.Request) api.Kernel {

--- a/internal/core/server/kernel.go
+++ b/internal/core/server/kernel.go
@@ -24,7 +24,6 @@ import (
 type Kernel struct {
 	VarDir      string
 	Store       state.Store
-	Telemetry   telemetry.Telemetry
 	TaskTracker *task.TaskTracker
 }
 
@@ -72,11 +71,12 @@ func (kern *Kernel) FindWorkspace(ctx context.Context, input *api.FindWorkspaceI
 }
 
 func (kern *Kernel) GetVersion(ctx context.Context, input *api.GetVersionInput) (*api.GetVersionOutput, error) {
+	tel := telemetry.FromContext(ctx)
 	installed := exo.Version
 	current := true
 	var latest *string
-	if kern.Telemetry.IsEnabled() {
-		latestVersion, err := kern.Telemetry.LatestVersion(ctx)
+	if tel.IsEnabled() {
+		latestVersion, err := tel.LatestVersion(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/server/kernel.go
+++ b/internal/core/server/kernel.go
@@ -76,7 +76,7 @@ func (kern *Kernel) GetVersion(ctx context.Context, input *api.GetVersionInput) 
 	current := true
 	var latest *string
 	if kern.Telemetry.IsEnabled() {
-		latestVersion, err := kern.Telemetry.LatestVersion()
+		latestVersion, err := kern.Telemetry.LatestVersion(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -40,12 +40,12 @@ func Main(ctx context.Context) {
 
 func RunServer(ctx context.Context, flags map[string]string) {
 	logger := logging.CurrentLogger(ctx)
+	tel := telemetry.FromContext(ctx)
 
 	cfg := &config.Config{}
 	config.MustLoadDefault(cfg)
 	paths := cmdutil.MustMakeDirectories(cfg)
 
-	tel := telemetry.New(ctx, &cfg.Telemetry)
 	tel.StartSession(ctx)
 
 	_, forceStdLog := flags["force-std-log"]
@@ -105,7 +105,6 @@ func RunServer(ctx context.Context, flags map[string]string) {
 	kernelCfg := &kernel.Config{
 		VarDir:      paths.VarDir,
 		Store:       store,
-		Telemetry:   tel,
 		SyslogPort:  cfg.Log.SyslogPort,
 		Docker:      dockerClient,
 		Logger:      logger,

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -45,8 +45,8 @@ func RunServer(ctx context.Context, flags map[string]string) {
 	config.MustLoadDefault(cfg)
 	paths := cmdutil.MustMakeDirectories(cfg)
 
-	tel := telemetry.New(&cfg.Telemetry)
-	tel.StartSession()
+	tel := telemetry.New(ctx, &cfg.Telemetry)
+	tel.StartSession(ctx)
 
 	_, forceStdLog := flags["force-std-log"]
 	if !(forceStdLog || isatty.IsTerminal(os.Stdout.Fd())) {

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -1,0 +1,15 @@
+package telemetry
+
+import "context"
+
+type contextKey int
+
+const telemetryKey contextKey = 1
+
+func ContextWithTelemetry(ctx context.Context, telemetry Telemetry) context.Context {
+	return context.WithValue(ctx, telemetryKey, telemetry)
+}
+
+func FromContext(ctx context.Context) Telemetry {
+	return ctx.Value(telemetryKey).(Telemetry)
+}

--- a/internal/telemetry/default.go
+++ b/internal/telemetry/default.go
@@ -2,22 +2,29 @@ package telemetry
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/deref/exo"
 	"github.com/deref/exo/internal/config"
 	"github.com/deref/exo/internal/util/cacheutil"
+	"github.com/deref/exo/internal/util/logging"
 )
 
 type defaultTelemetry struct {
-	cfg       *config.TelemetryConfig
-	client    *http.Client
-	sessionID string
+	ctx            context.Context
+	cfg            *config.TelemetryConfig
+	client         *http.Client
+	sessionID      string
+	operationGauge *SummaryGauge
 
 	latestVersion *cacheutil.TTLVal
+	getSession    sync.Once
 }
 
 func (t *defaultTelemetry) IsEnabled() bool {
@@ -26,43 +33,111 @@ func (t *defaultTelemetry) IsEnabled() bool {
 	return true
 }
 
-func (t *defaultTelemetry) StartSession() {
-	t.ensureSession()
+func (t *defaultTelemetry) StartSession(ctx context.Context) {
+	t.ensureSession(ctx)
 }
 
-func (t *defaultTelemetry) LatestVersion() (string, error) {
-	v, err := t.latestVersion.Get()
+func (t *defaultTelemetry) LatestVersion(ctx context.Context) (string, error) {
+	v, err := t.latestVersion.Get(ctx)
 	if err != nil {
 		return "", err
 	}
 	return v.(string), nil
 }
 
-func (t *defaultTelemetry) SendEvent(evt event) {
-	t.ensureSession()
-	var buf bytes.Buffer
-	req := telemetryRequest{
-		Method: "record-event",
-		Data: map[string]interface{}{
-			"id":      evt.ID(),
-			"payload": evt.Payload(),
-		},
-	}
-	e := json.NewEncoder(&buf)
-	e.Encode(req)
-	// Ignore response.
-	_, _ = t.client.Post(exo.TelemetryEndpoint, "application/json", &buf)
+func (t *defaultTelemetry) SendEvent(ctx context.Context, evt event) {
+	// TODO: Limit concurrent sends/throttle.
+	go func() {
+		t.ensureSession(ctx)
+		var buf bytes.Buffer
+		req := telemetryRequest{
+			Method: "record-event",
+			Data: map[string]interface{}{
+				"id":        evt.ID(),
+				"payload":   evt.Payload(),
+				"sessionId": t.sessionID,
+			},
+		}
+		e := json.NewEncoder(&buf)
+		e.Encode(req)
+		// Ignore response.
+		_, _ = t.client.Post(exo.TelemetryEndpoint, "application/json", &buf)
+	}()
 }
 
-func (t *defaultTelemetry) ensureSession() {
-	if t.sessionID == "" {
-		t.startSession()
+func (t *defaultTelemetry) RecordOperation(op OperationInvocation) {
+	var success string
+	if op.Success {
+		success = "y"
+	} else {
+		success = "n"
 	}
+
+	t.operationGauge.Observe(Tags{
+		"operation": op.Operation,
+		"success":   success,
+	}, float64(op.DurationMicros))
 }
 
-func (t *defaultTelemetry) startSession() {
-	// TODO: Start a session at the telemetry endpoint, and update the internal sessionID.
-	// This needs to be thread-safe.
+type startSessionResponse struct {
+	SessionID string `json:"sessionId"`
+}
+
+func (t *defaultTelemetry) ensureSession(ctx context.Context) {
+	if t.sessionID != "" {
+		return
+	}
+
+	t.getSession.Do(func() {
+		logger := logging.CurrentLogger(ctx)
+		errSetSession := func(res *http.Response, err error) {
+			var msg strings.Builder
+			msg.WriteString("Error creating session. Setting null UUID.")
+			if res != nil && res.StatusCode > 0 {
+				var responseText string
+				if responseBody, resErr := ioutil.ReadAll(res.Request.Body); resErr != nil {
+					responseText = "cannot read response"
+				} else {
+					responseText = string(responseBody)
+				}
+				msg.WriteString(fmt.Sprintf(" - HTTP %d: %q", res.StatusCode, responseText))
+			}
+
+			if err != nil {
+				msg.WriteString(fmt.Sprintf(": %v", err))
+			}
+
+			logger.Infof(msg.String())
+			t.sessionID = "00000000-0000-0000-0000-000000000000"
+		}
+
+		var buf bytes.Buffer
+		req := telemetryRequest{
+			Method: "start-session",
+		}
+		e := json.NewEncoder(&buf)
+		e.Encode(req)
+		res, err := t.client.Post(exo.TelemetryEndpoint, "application/json", &buf)
+		if err != nil {
+			errSetSession(res, err)
+			return
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != 200 {
+			errSetSession(res, nil)
+			return
+		}
+
+		typedRes := startSessionResponse{}
+		if err := json.NewDecoder(res.Body).Decode(&typedRes); err != nil {
+			errSetSession(res, err)
+			return
+		}
+
+		t.sessionID = typedRes.SessionID
+		logger.Infof("Started session: %q", t.sessionID)
+	})
 }
 
 func (t *defaultTelemetry) getLatestVersion() (interface{}, error) {
@@ -76,4 +151,34 @@ func (t *defaultTelemetry) getLatestVersion() (interface{}, error) {
 	}
 
 	return string(body), nil
+}
+
+func (t *defaultTelemetry) sendRecordedTelemetry() {
+	// There is the possibility of dropping data since we are not atomically
+	// swapping the pointer, but telemetry is only a best-effort attempt,
+	// so we do not care.
+	g := t.operationGauge
+	if len(g.buckets) == 0 {
+		return
+	}
+	t.operationGauge = newOperationGauge()
+
+	logging.CurrentLogger(t.ctx).Infof("Sending telemetry")
+
+	for _, bucket := range g.buckets {
+		tags := bucket.Tags()
+		op := tags["operation"]
+		success := tags["success"] == "y"
+		summary := bucket.Summarize()
+
+		t.SendEvent(t.ctx, &OperationsPerformed{
+			Operation:       op,
+			Success:         success,
+			DurationSummary: summary,
+		})
+	}
+}
+
+func newOperationGauge() *SummaryGauge {
+	return NewSummaryGauge([]string{"operation", "success"})
 }

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,5 +1,7 @@
 package telemetry
 
+import "github.com/deref/exo"
+
 type event interface {
 	ID() string
 	Payload() map[string]interface{}
@@ -21,5 +23,24 @@ func (e *SystemInfoIdentified) Payload() map[string]interface{} {
 	return map[string]interface{}{
 		"some": "data",
 		"goes": "here",
+	}
+}
+
+type OperationsPerformed struct {
+	Operation       string
+	Success         bool
+	DurationSummary SummaryStatistics
+}
+
+func (e *OperationsPerformed) ID() string {
+	return "a20fc050-ba26-4f05-832a-7d42283d1888"
+}
+
+func (e *OperationsPerformed) Payload() map[string]interface{} {
+	return map[string]interface{}{
+		"exoVersion": exo.Version,
+		"operation":  e.Operation,
+		"success":    e.Success,
+		"summary":    e.DurationSummary,
 	}
 }

--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -1,5 +1,7 @@
 package telemetry
 
+import "context"
+
 type noOpTelemetry struct {
 }
 
@@ -7,14 +9,18 @@ func (t *noOpTelemetry) IsEnabled() bool {
 	return false
 }
 
-func (t *noOpTelemetry) LatestVersion() (string, error) {
+func (t *noOpTelemetry) LatestVersion(_ context.Context) (string, error) {
 	return "", nil
 }
 
-func (t *noOpTelemetry) StartSession() {
+func (t *noOpTelemetry) StartSession(_ context.Context) {
 	// Do nothing.
 }
 
-func (t *noOpTelemetry) SendEvent(_ event) {
+func (t *noOpTelemetry) SendEvent(_ context.Context, _ event) {
+	// Do nothing.
+}
+
+func (t *noOpTelemetry) RecordOperation(_ OperationInvocation) {
 	// Do nothing.
 }

--- a/internal/telemetry/stats.go
+++ b/internal/telemetry/stats.go
@@ -1,0 +1,166 @@
+package telemetry
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type Tags map[string]string
+
+func NewSummaryGauge(tagLabels []string) *SummaryGauge {
+	return &SummaryGauge{
+		tagLabels: tagLabels,
+		buckets:   make(map[string]taggedSummaryBucket),
+	}
+}
+
+func (g *SummaryGauge) Observe(tags Tags, amount float64) {
+	orderedTagVals := make([]string, len(g.tagLabels))
+	for i, tagLabel := range g.tagLabels {
+		if tagVal, ok := tags[tagLabel]; ok {
+			// TODO: Escape null bytes.
+			orderedTagVals[i] = tagVal
+		} else {
+			// Empty value sentinel.
+			orderedTagVals[i] = "\xff"
+		}
+	}
+	key := strings.Join(orderedTagVals, "\x00")
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	taggedBucket, ok := g.buckets[key]
+	if !ok {
+		taggedBucket = taggedSummaryBucket{
+			tagLabels:     g.tagLabels,
+			tagValues:     orderedTagVals,
+			summaryBucket: &summaryBucket{},
+		}
+		g.buckets[key] = taggedBucket
+	}
+
+	taggedBucket.summaryBucket.observe(amount)
+}
+
+func (g *SummaryGauge) Buckets() []taggedSummaryBucket {
+	out := make([]taggedSummaryBucket, len(g.buckets))
+
+	var i int
+	for _, bucket := range g.buckets {
+		out[i] = bucket
+		i++
+	}
+
+	return out
+}
+
+type SummaryGauge struct {
+	tagLabels []string
+
+	mu      sync.Mutex
+	buckets map[string]taggedSummaryBucket
+}
+
+type taggedSummaryBucket struct {
+	*summaryBucket
+	tagLabels []string
+	tagValues []string
+}
+
+func (b *taggedSummaryBucket) TagValues() []string {
+	return b.tagValues
+}
+
+func (b *taggedSummaryBucket) Tags() Tags {
+	tags := make(Tags, len(b.tagLabels))
+	for i, tagLabel := range b.tagLabels {
+		tagValue := b.tagValues[i]
+		tags[tagLabel] = tagValue
+	}
+
+	return tags
+}
+
+func (b *taggedSummaryBucket) HasTagValues(tagValues []string) bool {
+	if len(tagValues) != len(b.tagValues) {
+		return false
+	}
+
+	for i, tv := range b.tagValues {
+		if tv != tagValues[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// summaryBucket keeps track of a number of observations then generates
+// `SummaryStatistics` from them.
+type summaryBucket struct {
+	mu           sync.Mutex
+	observations []float64
+}
+
+func (b *summaryBucket) observe(amount float64) {
+	b.mu.Lock()
+	b.observations = append(b.observations, amount)
+	b.mu.Unlock()
+}
+
+func (b *summaryBucket) Summarize() SummaryStatistics {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	stats := SummaryStatistics{
+		Count: len(b.observations),
+	}
+
+	if stats.Count == 0 {
+		return stats
+	}
+
+	stats.Min = math.Inf(1)
+	stats.Max = math.Inf(-1)
+	for _, amount := range b.observations {
+		stats.Sum += amount
+		stats.Min = math.Min(stats.Min, amount)
+		stats.Max = math.Max(stats.Max, amount)
+	}
+	stats.Mean = stats.Sum / float64(stats.Count)
+
+	// Calculate median.
+	sort.Float64s(b.observations)
+	middle := stats.Count / 2
+	if stats.Count%2 == 0 {
+		low := b.observations[middle-1]
+		high := b.observations[middle]
+		stats.Median = (low + high) / 2
+	} else {
+		stats.Median = b.observations[middle]
+	}
+
+	// Calculate standard deviation.
+	var sumSqDiffs float64
+	for _, amount := range b.observations {
+		diff := amount - stats.Mean
+		sumSqDiffs += diff * diff
+	}
+	variance := sumSqDiffs / float64(stats.Count)
+	stats.StdDev = math.Sqrt(variance)
+
+	return stats
+}
+
+type SummaryStatistics struct {
+	Count  int     `json:"count"`
+	Sum    float64 `json:"sum"`
+	Min    float64 `json:"min"`
+	Max    float64 `json:"max"`
+	Median float64 `json:"median"`
+	Mean   float64 `json:"mean"`
+	StdDev float64 `json:"stdDev"`
+}

--- a/internal/telemetry/stats_test.go
+++ b/internal/telemetry/stats_test.go
@@ -1,0 +1,82 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/deref/exo/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummaryGaugeNoTags(t *testing.T) {
+	g := telemetry.NewSummaryGauge(nil)
+	g.Observe(nil, -5)
+	g.Observe(nil, 1)
+	g.Observe(nil, 8)
+	g.Observe(nil, 7)
+	g.Observe(nil, 2)
+
+	buckets := g.Buckets()
+	assert.Len(t, buckets, 1)
+
+	stats := buckets[0].Summarize()
+
+	assert.Equal(t, 5, stats.Count)
+	assert.Equal(t, float64(13), stats.Sum)
+	assert.Equal(t, float64(-5), stats.Min)
+	assert.Equal(t, float64(8), stats.Max)
+	assert.Equal(t, float64(2), stats.Median)
+	assert.InDelta(t, 2.6, stats.Mean, 0.0000001)
+	assert.InDelta(t, 4.673328578, stats.StdDev, 0.000000001)
+}
+
+func TestSummaryGaugeWithTags(t *testing.T) {
+	g := telemetry.NewSummaryGauge([]string{"path", "status"})
+	g.Observe(telemetry.Tags{
+		"path":   "/about",
+		"status": "200",
+	}, 100)
+	g.Observe(telemetry.Tags{
+		"path":   "/",
+		"status": "200",
+	}, 600)
+	g.Observe(telemetry.Tags{
+		"path":   "/about",
+		"status": "200",
+	}, 300)
+	g.Observe(telemetry.Tags{
+		"path":   "/about",
+		"status": "401",
+	}, 25)
+
+	buckets := g.Buckets()
+	assert.Len(t, buckets, 3)
+
+	for _, bucket := range buckets {
+		if bucket.HasTagValues([]string{"/about", "200"}) {
+			assert.Equal(t, telemetry.Tags{
+				"path":   "/about",
+				"status": "200",
+			}, bucket.Tags())
+			assert.Equal(t, float64(200), bucket.Summarize().Mean)
+			continue
+		}
+
+		if bucket.HasTagValues([]string{"/", "200"}) {
+			assert.Equal(t, telemetry.Tags{
+				"path":   "/",
+				"status": "200",
+			}, bucket.Tags())
+			assert.Equal(t, float64(600), bucket.Summarize().Mean)
+			continue
+		}
+
+		if bucket.HasTagValues([]string{"/about", "401"}) {
+			assert.Equal(t, telemetry.Tags{
+				"path":   "/about",
+				"status": "401",
+			}, bucket.Tags())
+			assert.Equal(t, float64(25), bucket.Summarize().Mean)
+			continue
+		}
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,37 +1,66 @@
 package telemetry
 
 import (
+	"context"
+	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/deref/exo/internal/config"
 	"github.com/deref/exo/internal/util/cacheutil"
+	"github.com/deref/exo/internal/util/logging"
 )
 
 type Telemetry interface {
 	IsEnabled() bool
-	LatestVersion() (string, error)
-	StartSession()
-	SendEvent(event)
+	LatestVersion(context.Context) (string, error)
+	StartSession(context.Context)
+	SendEvent(context.Context, event)
+	RecordOperation(OperationInvocation)
 }
 
-func New(cfg *config.TelemetryConfig) Telemetry {
+func New(ctx context.Context, cfg *config.TelemetryConfig) Telemetry {
 	if cfg.Disable {
+		logging.CurrentLogger(ctx).Infof("Telemetry disabled; not collecting statistics.")
 		return &noOpTelemetry{}
 	}
 
 	t := &defaultTelemetry{
+		ctx: ctx,
 		cfg: cfg,
 		client: &http.Client{
 			Timeout: time.Second * 5,
 		},
+		operationGauge: newOperationGauge(),
 	}
 	t.latestVersion = cacheutil.NewTTLVal(t.getLatestVersion, 5*time.Minute)
+
+	go func() {
+		timerRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+		for {
+			// Wait between 120 and 600 seconds.
+			nextWait := timerRand.Intn(600-120) + 120
+			timer := time.NewTimer(time.Second * time.Duration(nextWait))
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				t.sendRecordedTelemetry()
+			}
+		}
+	}()
 
 	return t
 }
 
+type OperationInvocation struct {
+	Operation      string
+	DurationMicros int
+	Success        bool
+}
+
 type telemetryRequest struct {
-	Method string
-	Data   map[string]interface{}
+	Method string                 `json:"method"`
+	Data   map[string]interface{} `json:"data"`
 }

--- a/internal/util/cacheutil/ttlval.go
+++ b/internal/util/cacheutil/ttlval.go
@@ -1,6 +1,7 @@
 package cacheutil
 
 import (
+	"context"
 	"time"
 )
 
@@ -23,7 +24,7 @@ func NewTTLVal(getVal valFunc, ttl time.Duration) *TTLVal {
 	}
 }
 
-func (v *TTLVal) Get() (interface{}, error) {
+func (v *TTLVal) Get(ctx context.Context) (interface{}, error) {
 	if time.Now().Sub(v.runAt) > v.ttl {
 		val, err := v.getVal()
 		if err != nil {


### PR DESCRIPTION
This PR adds session tracking for each `exo` daemon run and aggregate statistics for any method invoked. The telemetry requests are proxied through `https://exo.deref.io/api/telemetry` (see [the api function](https://github.com/deref/exo-website/blob/main/pages/api/telemetry.ts)) to Hasura, where they are stored in the database with an association to the exo session to which they belong. See below for an example payload. All time-based stats are in microseconds.

![image](https://user-images.githubusercontent.com/1010813/128756918-5d6e08de-a677-48bf-a722-65f2988480ec.png)
