### PR TITLE
dispose/delete components now bulk

### DIFF
--- a/cmd/exo/dispose.go
+++ b/cmd/exo/dispose.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/deref/exo/internal/core/api"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(disposeCmd)
+}
+
+var disposeCmd = &cobra.Command{
+	Use:    "dispose [ref ...]",
+	Short:  "Disposes components",
+	Long:   "Disposes components.",
+	Hidden: true, // This command is only really useful for testing controllers.
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := newContext()
+		ensureDaemon()
+		cl := newClient()
+		workspace := requireWorkspace(ctx, cl)
+		_, err := workspace.DisposeComponents(ctx, &api.DisposeComponentsInput{
+			Refs: args,
+		})
+		return err
+	},
+}

--- a/cmd/exo/rm.go
+++ b/cmd/exo/rm.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/deref/exo/internal/core/api"
 	"github.com/spf13/cobra"
 )
@@ -24,15 +22,9 @@ var rmCmd = &cobra.Command{
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 
-		// TODO: Bulk delete operation.
-		for _, ref := range args {
-			_, err := workspace.DeleteComponent(ctx, &api.DeleteComponentInput{
-				Ref: ref,
-			})
-			if err != nil {
-				return fmt.Errorf("deleting %q: %w", ref, err)
-			}
-		}
-		return nil
+		_, err := workspace.DeleteComponents(ctx, &api.DeleteComponentsInput{
+			Refs: args,
+		})
+		return err
 	},
 }

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -66,10 +66,10 @@ type Workspace interface {
 	UpdateComponent(context.Context, *UpdateComponentInput) (*UpdateComponentOutput, error)
 	// Asycnhronously refreshes component state.
 	RefreshComponents(context.Context, *RefreshComponentsInput) (*RefreshComponentsOutput, error)
-	// Marks a component as disposed and triggers the dispose lifecycle event. After being disposed, the component record will be deleted asynchronously.
-	DisposeComponent(context.Context, *DisposeComponentInput) (*DisposeComponentOutput, error)
-	// Disposes a component and then awaits the record to be deleted synchronously.
-	DeleteComponent(context.Context, *DeleteComponentInput) (*DeleteComponentOutput, error)
+	// Disposes the resource associated with a components.
+	DisposeComponents(context.Context, *DisposeComponentsInput) (*DisposeComponentsOutput, error)
+	// Disposes components, then removes their manifest entries.
+	DeleteComponents(context.Context, *DeleteComponentsInput) (*DeleteComponentsOutput, error)
 	DescribeLogs(context.Context, *DescribeLogsInput) (*DescribeLogsOutput, error)
 	// Returns pages of log events for some set of logs. If `cursor` is specified, standard pagination behavior is used. Otherwise the cursor is assumed to represent the current tail of the log.
 	GetEvents(context.Context, *GetEventsInput) (*GetEventsOutput, error)
@@ -156,18 +156,18 @@ type RefreshComponentsOutput struct {
 	JobID string `json:"jobId"`
 }
 
-type DisposeComponentInput struct {
-	Ref string `json:"ref"`
+type DisposeComponentsInput struct {
+	Refs []string `json:"refs"`
 }
 
-type DisposeComponentOutput struct {
+type DisposeComponentsOutput struct {
 }
 
-type DeleteComponentInput struct {
-	Ref string `json:"ref"`
+type DeleteComponentsInput struct {
+	Refs []string `json:"refs"`
 }
 
-type DeleteComponentOutput struct {
+type DeleteComponentsOutput struct {
 }
 
 type DescribeLogsInput struct {
@@ -271,11 +271,11 @@ func BuildWorkspaceMux(b *josh.MuxBuilder, factory func(req *http.Request) Works
 	b.AddMethod("refresh-components", func(req *http.Request) interface{} {
 		return factory(req).RefreshComponents
 	})
-	b.AddMethod("dispose-component", func(req *http.Request) interface{} {
-		return factory(req).DisposeComponent
+	b.AddMethod("dispose-components", func(req *http.Request) interface{} {
+		return factory(req).DisposeComponents
 	})
-	b.AddMethod("delete-component", func(req *http.Request) interface{} {
-		return factory(req).DeleteComponent
+	b.AddMethod("delete-components", func(req *http.Request) interface{} {
+		return factory(req).DeleteComponents
 	})
 	b.AddMethod("describe-logs", func(req *http.Request) interface{} {
 		return factory(req).DescribeLogs

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -90,17 +90,16 @@ interface "workspace" {
     output "job-id" "string" {}
   }
 
-  method "dispose-component" {
-    # TODO: Line breaks in doc strings.
-    doc = "Marks a component as disposed and triggers the dispose lifecycle event. After being disposed, the component record will be deleted asynchronously."
+  method "dispose-components" {
+    doc = "Disposes the resource associated with a components."
 
-    input "ref" "string" {}
+    input "refs" "[]string" {}
   }
 
-  method "delete-component" {
-    doc = "Disposes a component and then awaits the record to be deleted synchronously."
+  method "delete-components" {
+    doc = "Disposes components, then removes their manifest entries."
 
-    input "ref" "string" {}
+    input "refs" "[]string" {}
   }
 
   method "describe-logs" {

--- a/internal/core/client/workspace.go
+++ b/internal/core/client/workspace.go
@@ -103,13 +103,13 @@ func (c *Workspace) RefreshComponents(ctx context.Context, input *api.RefreshCom
 	return
 }
 
-func (c *Workspace) DisposeComponent(ctx context.Context, input *api.DisposeComponentInput) (output *api.DisposeComponentOutput, err error) {
-	err = c.client.Invoke(ctx, "dispose-component", input, &output)
+func (c *Workspace) DisposeComponents(ctx context.Context, input *api.DisposeComponentsInput) (output *api.DisposeComponentsOutput, err error) {
+	err = c.client.Invoke(ctx, "dispose-components", input, &output)
 	return
 }
 
-func (c *Workspace) DeleteComponent(ctx context.Context, input *api.DeleteComponentInput) (output *api.DeleteComponentOutput, err error) {
-	err = c.client.Invoke(ctx, "delete-component", input, &output)
+func (c *Workspace) DeleteComponents(ctx context.Context, input *api.DeleteComponentsInput) (output *api.DeleteComponentsOutput, err error) {
+	err = c.client.Invoke(ctx, "delete-components", input, &output)
 	return
 }
 


### PR DESCRIPTION
I was doing work for progress reporting on dispose, delete, etc and it was just getting too big, so I extracted this initial change to make these operations bulk. Later, they will become parallel & report progress.