### PR TITLE
Improve process detail table styling

### DIFF
--- a/gui/src/components/CheckeredTableWrapper.svelte
+++ b/gui/src/components/CheckeredTableWrapper.svelte
@@ -1,3 +1,17 @@
+<!-- 
+  This component styles any <table> within the <slot /> with a checkered row-and-column tiger stripe
+    as well as some shadowing and general style improvements for enhanced legibility.
+
+  Please ensure your table has the structure:
+  * table
+    * thead (optional)
+    * ...tr...
+      * ...th...
+    * tbody
+    * ...tr...
+      * ...td...
+-->
+
 <div>
   <slot />
 </div>

--- a/gui/src/components/CheckeredTableWrapper.svelte
+++ b/gui/src/components/CheckeredTableWrapper.svelte
@@ -1,0 +1,48 @@
+<div>
+  <slot />
+</div>
+
+<style>
+  div :global(table) {
+    border: none;
+    border-collapse: collapse;
+    border-radius: 0.25em;
+    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
+      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+  }
+
+  div :global(td),
+  div :global(th) {
+    text-align: left;
+    padding: 6px 15px;
+  }
+
+  div :global(th:nth-child(2n)) {
+    background: #f9f9f9;
+  }
+
+  div :global(tbody tr:nth-child(2n + 1)) {
+    background: #eeeeee;
+  }
+
+  div :global(tbody tr:nth-child(2n)) {
+    background: #ffffff;
+  }
+
+  div :global(tbody tr:nth-child(2n + 1) td:nth-child(2n)) {
+    background: #e7e7e7;
+  }
+
+  div :global(tbody tr:nth-child(2n) td:nth-child(2n)) {
+    background: #f9f9f9;
+  }
+
+  div :global(tr:first-child > *) {
+    padding-top: 10px;
+  }
+
+  div :global(tr:last-child > *) {
+    padding-bottom: 10px;
+  }
+</style>

--- a/gui/src/components/ComponentTable.svelte
+++ b/gui/src/components/ComponentTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SvelteConstructor } from '../lib/svelte';
+  import CheckeredTableWrapper from './CheckeredTableWrapper.svelte';
   import ErrorLabel from './ErrorLabel.svelte';
   import Spinner from './mono/spinner.svelte';
 
@@ -24,77 +25,34 @@
   {#if components.length === 0}
     <div>No records</div>
   {:else}
-    <table>
-      <thead>
-        <tr>
-          {#each columns as column}
-            <th>
-              {column.title}
-            </th>
-          {/each}
-        </tr>
-      </thead>
-      <tbody>
-        {#each components as component}
+    <CheckeredTableWrapper>
+      <table>
+        <thead>
           <tr>
             {#each columns as column}
-              <td>
-                <svelte:component
-                  this={column.component}
-                  value={column.getValue(component)}
-                />
-              </td>
+              <th>
+                {column.title}
+              </th>
             {/each}
           </tr>
-        {/each}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {#each components as component}
+            <tr>
+              {#each columns as column}
+                <td>
+                  <svelte:component
+                    this={column.component}
+                    value={column.getValue(component)}
+                  />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </CheckeredTableWrapper>
   {/if}
 {:catch ex}
   <ErrorLabel value={ex} />
 {/await}
-
-<style>
-  table {
-    border: none;
-    border-collapse: collapse;
-    border-radius: 0.25em;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-  }
-
-  td,
-  th {
-    text-align: left;
-    padding: 5px 15px;
-  }
-
-  th:nth-child(2n) {
-    background: #f9f9f9;
-  }
-
-  tbody tr:nth-child(2n + 1) {
-    background: #eeeeee;
-  }
-
-  tbody tr:nth-child(2n) {
-    background: #ffffff;
-  }
-
-  tbody tr:nth-child(2n + 1) td:nth-child(2n) {
-    background: #e7e7e7;
-  }
-
-  tbody tr:nth-child(2n) td:nth-child(2n) {
-    background: #f9f9f9;
-  }
-
-  tr:first-child > * {
-    padding-top: 10px;
-  }
-
-  tr:last-child > * {
-    padding-bottom: 10px;
-  }
-</style>

--- a/gui/src/pages/Process.svelte
+++ b/gui/src/pages/Process.svelte
@@ -179,9 +179,12 @@
 
   code {
     width: 100%;
-    max-width: 500px;
+    max-width: 600px;
     display: inline-block;
     overflow-x: auto;
+    font-size: 1.05em;
+    padding: 6px;
+    margin: -8px;
   }
 
   table tr:nth-child(2n + 1) {

--- a/gui/src/pages/Process.svelte
+++ b/gui/src/pages/Process.svelte
@@ -12,6 +12,7 @@
   import type { RemoteData } from '../lib/api';
   import BytesLabel from '../components/BytesLabel.svelte';
   import WithLeftWorkspaceNav from '../components/WithLeftWorkspaceNav.svelte';
+  import CheckeredTableWrapper from '../components/CheckeredTableWrapper.svelte';
   import type { ProcessDescription } from 'src/lib/process/types';
   export let params = { workspace: '', process: '' };
 
@@ -73,67 +74,77 @@
             <h1>{process.name}</h1>
           </div>
           {#if process.running}
-            <table>
-              <tr>
-                <td class="label">Status</td>
-                <td>{process.running ? 'Running' : 'Stopped'}</td>
-                <td />
-              </tr>
-              <tr>
-                <td class="label">CPU</td>
-                <td>{process.cpuPercent.toFixed(2)}%</td>
-                <td
-                  ><svg
-                    bind:this={sparklineSvg}
-                    class="sparkline"
-                    width="100"
-                    height="30"
-                    stroke-width="3"
-                  /></td
-                >
-              </tr>
-              <tr>
-                <td class="label">Resident Memory</td>
-                <td><BytesLabel value={process.residentMemory} /></td>
-                <td />
-              </tr>
-              <tr>
-                <td class="label">Started at</td>
-                <td
-                  ><span title={new Date(process.createTime).toISOString()}
-                    >{new Date(process.createTime).toLocaleTimeString()}</span
-                  ></td
-                >
-                <td
-                  ><svg
-                    class="sparkline"
-                    width="100"
-                    height="30"
-                    stroke-width="3"
-                  /></td
-                >
-              </tr>
-              <tr>
-                <td class="label">Local Ports</td>
-                <td>{process.ports?.join(', ') ?? 'None'}</td>
-                <td />
-              </tr>
-              <tr>
-                <td class="label">Children</td>
-                <td>{process.childrenExecutables?.join(', ') ?? 'None'}</td>
-                <td />
-              </tr>
-            </table>
+            <CheckeredTableWrapper>
+              <table>
+                <tbody>
+                  <tr>
+                    <td class="label">Status</td>
+                    <td>{process.running ? 'Running' : 'Stopped'}</td>
+                    <td />
+                  </tr>
+                  <tr>
+                    <td class="label">CPU</td>
+                    <td>{process.cpuPercent.toFixed(2)}%</td>
+                    <td
+                      ><svg
+                        bind:this={sparklineSvg}
+                        class="sparkline"
+                        width="100"
+                        height="30"
+                        stroke-width="3"
+                      /></td
+                    >
+                  </tr>
+                  <tr>
+                    <td class="label">Resident Memory</td>
+                    <td><BytesLabel value={process.residentMemory} /></td>
+                    <td />
+                  </tr>
+                  <tr>
+                    <td class="label">Started at</td>
+                    <td
+                      ><span title={new Date(process.createTime).toISOString()}
+                        >{new Date(
+                          process.createTime,
+                        ).toLocaleTimeString()}</span
+                      ></td
+                    >
+                    <td
+                      ><svg
+                        class="sparkline"
+                        width="100"
+                        height="30"
+                        stroke-width="3"
+                      /></td
+                    >
+                  </tr>
+                  <tr>
+                    <td class="label">Local Ports</td>
+                    <td>{process.ports?.join(', ') ?? 'None'}</td>
+                    <td />
+                  </tr>
+                  <tr>
+                    <td class="label">Children</td>
+                    <td>{process.childrenExecutables?.join(', ') ?? 'None'}</td>
+                    <td />
+                  </tr>
+                </tbody>
+              </table>
+            </CheckeredTableWrapper>
             <br />
             <h3>Environment</h3>
-            <table>
-              {#each Object.entries(process.envVars ?? {}) as [name, val] (name)}
-                <tr>
-                  <td class="label">{name}</td>
-                  <td><code><pre>{val}</pre></code></td>
-                </tr>
-              {/each}
-            </table>
+            <CheckeredTableWrapper>
+              <tbody>
+                <table>
+                  {#each Object.entries(process.envVars ?? {}) as [name, val] (name)}
+                    <tr>
+                      <td class="label">{name}</td>
+                      <td><code><pre>{val}</pre></code></td>
+                    </tr>
+                  {/each}
+                </table>
+              </tbody>
+            </CheckeredTableWrapper>
             <br />
           {:else}
             <p>Process is not running</p>
@@ -161,20 +172,7 @@
   .sparkline {
     stroke: red;
     fill: none;
-    margin: -8px -16px;
-  }
-
-  table {
-    border-collapse: collapse;
-    border-radius: 0.25em;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-  }
-
-  td {
-    text-align: left;
-    padding: 8px 16px;
+    margin: -6px -15px;
   }
 
   code {
@@ -183,24 +181,8 @@
     display: inline-block;
     overflow-x: auto;
     font-size: 1.05em;
-    padding: 6px;
-    margin: -8px;
-  }
-
-  table tr:nth-child(2n + 1) {
-    background: #eeeeee;
-  }
-
-  table tr:nth-child(2n) {
-    background: #ffffff;
-  }
-
-  table tr:nth-child(2n + 1) td:nth-child(2n) {
-    background: #e7e7e7;
-  }
-
-  table tr:nth-child(2n) td:nth-child(2n) {
-    background: #f9f9f9;
+    padding: 8px;
+    margin: -10px;
   }
 
   .label {

--- a/gui/src/pages/Process.svelte
+++ b/gui/src/pages/Process.svelte
@@ -78,6 +78,7 @@
               <tr>
                 <td>Status</td>
                 <td>{process.running ? 'Running' : 'Stopped'}</td>
+                <td />
               </tr>
               <tr>
                 <td>CPU</td>
@@ -95,6 +96,7 @@
               <tr>
                 <td>Resident Memory</td>
                 <td><BytesLabel value={process.residentMemory} /></td>
+                <td />
               </tr>
               <tr>
                 <td>Started at</td>
@@ -115,21 +117,25 @@
               <tr>
                 <td>Local Ports</td>
                 <td>{process.ports?.join(', ') ?? 'None'}</td>
+                <td />
               </tr>
               <tr>
                 <td>Children</td>
                 <td>{process.childrenExecutables?.join(', ') ?? 'None'}</td>
+                <td />
               </tr>
             </table>
+            <br />
             <h3>Environment</h3>
             <table>
               {#each Object.entries(process.envVars ?? {}) as [name, val] (name)}
                 <tr>
-                  <td>{name}</td>
+                  <td class="label">{name}</td>
                   <td><code><pre>{val}</pre></code></td>
                 </tr>
               {/each}
             </table>
+            <br />
           {:else}
             <p>Process is not running</p>
           {/if}
@@ -158,43 +164,54 @@
     fill: none;
   }
 
+  table {
+    border-collapse: collapse;
+    border-radius: 0.25em;
+    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
+      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+  }
+
+  td {
+    text-align: left;
+    padding: 8px 16px;
+  }
+
   code {
     width: 100%;
     max-width: 500px;
     display: inline-block;
     overflow-x: auto;
-    padding: 0.6em;
-    border-radius: 0.5em;
-    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  table tr:nth-child(2n + 1) {
+    background: #eeeeee;
+  }
+
+  table tr:nth-child(2n) {
+    background: #ffffff;
+  }
+
+  table tr:nth-child(2n + 1) td:nth-child(2n) {
+    background: #e7e7e7;
+  }
+
+  table tr:nth-child(2n) td:nth-child(2n) {
+    background: #f9f9f9;
   }
 
   td {
     padding-right: 2em;
   }
 
+  .label {
+    font-size: 0.8em;
+    font-weight: 450;
+  }
+
   /* line with highlight area */
   .sparkline {
     stroke: red;
     fill: rgba(255, 0, 0, 0.3);
-  }
-
-  /* change the spot color */
-  .sparkline--spot {
-    stroke: blue;
-    fill: blue;
-  }
-
-  /* change the cursor color */
-  .sparkline--cursor {
-    stroke: orange;
-  }
-
-  /* style fill area and line colors using specific class name */
-  .sparkline--fill {
-    fill: rgba(255, 0, 0, 0.3);
-  }
-
-  .sparkline--line {
-    stroke: red;
   }
 </style>

--- a/gui/src/pages/Process.svelte
+++ b/gui/src/pages/Process.svelte
@@ -72,16 +72,15 @@
           <div id="heading">
             <h1>{process.name}</h1>
           </div>
-          <h3>Status</h3>
           {#if process.running}
             <table>
               <tr>
-                <td>Status</td>
+                <td class="label">Status</td>
                 <td>{process.running ? 'Running' : 'Stopped'}</td>
                 <td />
               </tr>
               <tr>
-                <td>CPU</td>
+                <td class="label">CPU</td>
                 <td>{process.cpuPercent.toFixed(2)}%</td>
                 <td
                   ><svg
@@ -94,12 +93,12 @@
                 >
               </tr>
               <tr>
-                <td>Resident Memory</td>
+                <td class="label">Resident Memory</td>
                 <td><BytesLabel value={process.residentMemory} /></td>
                 <td />
               </tr>
               <tr>
-                <td>Started at</td>
+                <td class="label">Started at</td>
                 <td
                   ><span title={new Date(process.createTime).toISOString()}
                     >{new Date(process.createTime).toLocaleTimeString()}</span
@@ -115,12 +114,12 @@
                 >
               </tr>
               <tr>
-                <td>Local Ports</td>
+                <td class="label">Local Ports</td>
                 <td>{process.ports?.join(', ') ?? 'None'}</td>
                 <td />
               </tr>
               <tr>
-                <td>Children</td>
+                <td class="label">Children</td>
                 <td>{process.childrenExecutables?.join(', ') ?? 'None'}</td>
                 <td />
               </tr>
@@ -162,6 +161,7 @@
   .sparkline {
     stroke: red;
     fill: none;
+    margin: -8px -16px;
   }
 
   table {
@@ -200,13 +200,10 @@
     background: #f9f9f9;
   }
 
-  td {
-    padding-right: 2em;
-  }
-
   .label {
     font-size: 0.8em;
     font-weight: 450;
+    color: #555555;
   }
 
   /* line with highlight area */


### PR DESCRIPTION
Adds similar styling as the docker component read page tables to the process details tables. Should abstract this table styling to a generic underlying component before merging.

![image](https://user-images.githubusercontent.com/51100181/128809340-d935da8b-ed6e-4554-8fc2-66a766f7199a.png)
