### PR TITLE
Colors in logs

### DIFF
--- a/cmd/rainbows/main.go
+++ b/cmd/rainbows/main.go
@@ -1,0 +1,66 @@
+// Generates test data for log viewers containing colors and fonts.
+package main
+
+import (
+	"fmt"
+
+	"github.com/aybabtme/rgbterm"
+)
+
+func main() {
+	{
+		fmt.Println("8 Colors")
+		for i := 0; i < 8; i++ {
+			fmt.Printf("\u001b[%dmX", 30+i)
+		}
+		fmt.Println("\u001b[0m")
+	}
+
+	fmt.Println()
+	{
+		fmt.Println("16 Colors")
+		for i := 0; i < 16; i++ {
+			fmt.Printf("\u001b[%d;1mX", 30+i)
+		}
+		fmt.Println("\u001b[0m")
+	}
+
+	fmt.Println()
+	{
+		fmt.Println("256 Colors")
+		for i := 0; i < 16; i++ {
+			for j := 0; j < 16; j++ {
+				fmt.Printf("\u001b[38;5;%04dmX", i*16+j)
+			}
+			fmt.Println("\u001b[0m")
+		}
+	}
+
+	fmt.Println()
+	{
+		fmt.Println("24-bit Color")
+		i := 0
+		for h := 0; h < 256; h++ {
+			r, g, b := rgbterm.HSLtoRGB(float64(h)/256.0, 0.7, 0.5)
+			fmt.Print(rgbterm.FgString("X", r, g, b))
+			i++
+			if i%32 == 0 {
+				fmt.Println()
+			}
+		}
+	}
+
+	fmt.Println()
+	{
+		fmt.Println("decorations")
+		fmt.Println("\u001b[1mBold\u001b[0m")
+		fmt.Println("\u001b[2mFaint\u001b[0m")
+		fmt.Println("\u001b[3mItalic\u001b[0m")
+		fmt.Println("\u001b[4mUnderline\u001b[0m")
+		fmt.Println("\u001b[5mSlow Blink\u001b[0m")
+		fmt.Println("\u001b[6mFast Blink\u001b[0m") // Unsupported in Terminal.app on Mac.
+		fmt.Println("\u001b[7mInvert\u001b[0m")
+		fmt.Println("\u001b[8mConceal\u001b[0m")
+		fmt.Println("\u001b[9mStrikethrough\u001b[0m") // Unsupported in Terminal.app on Mac.
+	}
+}

--- a/gui/src/components/logs/FormattedLogMessage.stories.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.stories.svelte
@@ -23,3 +23,10 @@
       'This message uses a   string with a https://deref.io URL in it and formats  an anchor tag with the link.',
   }}
 />
+
+<Story
+  name="Rainbow"
+  args={{
+    message: `[30mX[31mX[32mX[33mX[34mX[35mX[36mX[37mX[0m`,
+  }}
+/>

--- a/gui/src/components/logs/FormattedLogMessage.stories.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.stories.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { range } from '../../lib/arrays';
   import FormattedLogMessage from './FormattedLogMessage.svelte';
 </script>
 
@@ -25,8 +26,33 @@
 />
 
 <Story
-  name="Rainbow"
+  name="Colors: 4 bit"
   args={{
-    message: `[30mX[31mX[32mX[33mX[34mX[35mX[36mX[37mX[0m`,
+    message: [
+      `\u001b[30mX\u001b[31mX\u001b[32mX\u001b[33mX\u001b[34mX\u001b[35mX\u001b[36mX\u001b[37mX\u001b[0m `,
+      `\u001b[40mX\u001b[41mX\u001b[42mX\u001b[43mX\u001b[44mX\u001b[45mX\u001b[46mX\u001b[47mX\u001b[0m `,
+      `\u001b[90mX\u001b[91mX\u001b[92mX\u001b[93mX\u001b[94mX\u001b[95mX\u001b[96mX\u001b[97mX\u001b[0m `,
+      `\u001b[100mX\u001b[101mX\u001b[102mX\u001b[103mX\u001b[104mX\u001b[105mX\u001b[106mX\u001b[107mX\u001b[0m `,
+    ].join(''),
+  }}
+/>
+
+<Story
+  name="Colors: 8 bit"
+  args={{
+    message:
+      range(256)
+        .map((i) => `\u001b[38;5;${i};m ${i}`)
+        .join('') +
+      range(256)
+        .map((i) => `\u001b[48;5;${i};m ${i}`)
+        .join(''),
+  }}
+/>
+
+<Story
+  name="Text Decorations"
+  args={{
+    message: `\u001b[1mBold\u001b[0m \u001b[2mFaint\u001b[0m \u001b[3mItalic\u001b[0m \u001b[4mUnderline\u001b[0m \u001b[9mStrikethrough`,
   }}
 />

--- a/gui/src/components/logs/FormattedLogMessage.stories.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.stories.svelte
@@ -61,6 +61,6 @@
 <Story
   name="Text Decorations"
   args={{
-    message: `\u001b[1mBold\u001b[0m \u001b[2mFaint\u001b[0m \u001b[3mItalic\u001b[0m \u001b[4mUnderline\u001b[0m \u001b[9mStrikethrough`,
+    message: `\u001b[1mBold\u001b[0m \u001b[2mFaint\u001b[0m \u001b[3mItalic\u001b[0m \u001b[4mUnderline\u001b[0m \u001b[5mBlink\u001b[0m \u001b[7mInvert\u001b[0m \u001b[9mStrikethrough`,
   }}
 />

--- a/gui/src/components/logs/FormattedLogMessage.stories.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.stories.svelte
@@ -18,10 +18,18 @@
 />
 
 <Story
+  name="Whitespace"
+  args={{
+    message:
+      'This half of the sentence is separated...                         ...from this half by many spaces',
+  }}
+/>
+
+<Story
   name="With Link"
   args={{
     message:
-      'This message uses a   string with a https://deref.io URL in it and formats  an anchor tag with the link.',
+      'This message uses a string with a https://deref.io URL in it and formats  an anchor tag with the link.',
   }}
 />
 

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -49,3 +49,10 @@
     {/if}
   {/each}
 </span>
+
+<style>
+  a,
+  span {
+    white-space: pre;
+  }
+</style>

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -10,8 +10,8 @@
     const addStyle = (key: string, value: string) => {
       styles.push(`${key}: ${value}`);
     };
-    if (span.forground != null) {
-      addStyle('color', span.forground);
+    if (span.foreground != null) {
+      addStyle('color', span.foreground);
     }
     if (span.background != null) {
       addStyle('background', span.background);

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { parseSpans } from './parseSpans';
+  import { parseSpans, Span } from './parseSpans';
 
   export let message: string = '';
 
@@ -8,7 +8,7 @@
 
 <span>
   {#each spans as span}
-    {#if span.type === 'link'}
+    {#if span.href != null}
       <a href={span.href}>{span.text}</a>
     {:else}
       <span>{span.text}</span>

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -5,8 +5,9 @@
 
   const spans = parseSpans(message);
 
-  const spanStyle = (span: Span): string => {
+  const spanProps = (span: Span): Record<string, string | boolean> => {
     const styles: string[] = [];
+    const classes: string[] = [];
     const addStyle = (key: string, value: string) => {
       styles.push(`${key}: ${value}`);
     };
@@ -28,24 +29,34 @@
         break;
       case 'underline':
         addStyle('text-decoration', 'underline');
+        break;
       case 'blink':
+        classes.push('exo-message-blink');
+        break;
       case 'invert':
-        // Not supported (yet?).
+        classes.push('exo-message-invert');
         break;
       case 'strike':
         addStyle('text-decoration', 'line-through');
         break;
     }
-    return styles.join(';');
+    const props: Record<string, string | boolean> = {};
+    if (styles.length > 0) {
+      props['style'] = styles.join(':');
+    }
+    if (classes.length > 0) {
+      props['class'] = classes.join(' ');
+    }
+    return props;
   };
 </script>
 
 <span>
   {#each spans as span}
     {#if span.href != null}
-      <a href={span.href} style={spanStyle(span)}>{span.text}</a>
+      <a href={span.href} {...spanProps(span)}>{span.text}</a>
     {:else}
-      <span style={spanStyle(span)}>{span.text}</span>
+      <span {...spanProps(span)}>{span.text}</span>
     {/if}
   {/each}
 </span>
@@ -54,5 +65,33 @@
   a,
   span {
     white-space: pre;
+  }
+
+  :global(.exo-message-blink) {
+    animation: blink 1s linear infinite;
+  }
+
+  @keyframes blink {
+    0% {
+      visibility: hidden;
+    }
+    50% {
+      visibility: hidden;
+    }
+    100% {
+      visibility: visible;
+    }
+  }
+
+  :global(.exo-message-invert) {
+    background: white;
+    filter: invert(1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(.exo-message-invert) {
+      background: black;
+      filter: invert(1);
+    }
   }
 </style>

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -4,17 +4,48 @@
   export let message: string = '';
 
   const spans = parseSpans(message);
+
+  const spanStyle = (span: Span): string => {
+    const styles: string[] = [];
+    const addStyle = (key: string, value: string) => {
+      styles.push(`${key}: ${value}`);
+    };
+    if (span.forground != null) {
+      addStyle('color', span.forground);
+    }
+    if (span.background != null) {
+      addStyle('background', span.background);
+    }
+    switch (span.style) {
+      case 'bold':
+        addStyle('font-weight', 'bold');
+        break;
+      case 'faint':
+        addStyle('font-weight', 'lighter');
+        break;
+      case 'italic':
+        addStyle('font-style', 'italic');
+        break;
+      case 'underline':
+        addStyle('text-decoration', 'underline');
+      case 'blink':
+      case 'invert':
+        // Not supported (yet?).
+        break;
+      case 'strike':
+        addStyle('text-decoration', 'line-through');
+        break;
+    }
+    return styles.join(';');
+  };
 </script>
 
 <span>
   {#each spans as span}
     {#if span.href != null}
-      <a href={span.href}>{span.text}</a>
+      <a href={span.href} style={spanStyle(span)}>{span.text}</a>
     {:else}
-      <span>{span.text}</span>
+      <span style={spanStyle(span)}>{span.text}</span>
     {/if}
   {/each}
 </span>
-
-<style>
-</style>

--- a/gui/src/components/logs/parseSpans.test.ts
+++ b/gui/src/components/logs/parseSpans.test.ts
@@ -45,15 +45,15 @@ test('parseSpans', () => {
 
   check('\u001b[31mRed\u001b[32mGreen\u001b34mBlue', [
     {
-      forground: '#ff0000',
+      foreground: '#ff0000',
       text: 'Red',
     },
     {
-      forground: '#00ff00',
+      foreground: '#00ff00',
       text: 'Green',
     },
     {
-      forground: '#0000ff',
+      foreground: '#0000ff',
       text: 'Blue',
     },
   ]);

--- a/gui/src/components/logs/parseSpans.test.ts
+++ b/gui/src/components/logs/parseSpans.test.ts
@@ -9,44 +9,36 @@ test('parseSpans', () => {
   check('', []);
   check('asdf', [
     {
-      type: 'plain',
       text: 'asdf',
     },
   ]);
   check('https://foo.com', [
     {
-      type: 'link',
       href: 'https://foo.com',
       text: 'https://foo.com',
     },
   ]);
   check('foo https://foo.com bar', [
     {
-      type: 'plain',
       text: 'foo ',
     },
     {
-      type: 'link',
       href: 'https://foo.com',
       text: 'https://foo.com',
     },
     {
-      type: 'plain',
       text: ' bar',
     },
   ]);
   check('foo <https://foo.com> bar', [
     {
-      type: 'plain',
       text: 'foo <',
     },
     {
-      type: 'link',
       href: 'https://foo.com',
       text: 'https://foo.com',
     },
     {
-      type: 'plain',
       text: '> bar',
     },
   ]);

--- a/gui/src/components/logs/parseSpans.test.ts
+++ b/gui/src/components/logs/parseSpans.test.ts
@@ -42,4 +42,19 @@ test('parseSpans', () => {
       text: '> bar',
     },
   ]);
+
+  check('\u001b[31mRed\u001b[32mGreen\u001b34mBlue', [
+    {
+      forground: '#ff0000',
+      text: 'Red',
+    },
+    {
+      forground: '#00ff00',
+      text: 'Green',
+    },
+    {
+      forground: '#0000ff',
+      text: 'Blue',
+    },
+  ]);
 });

--- a/gui/src/components/logs/parseSpans.ts
+++ b/gui/src/components/logs/parseSpans.ts
@@ -1,17 +1,6 @@
-export type Span = Plain | Link;
-
-export interface SpanBase {
-  type: string;
+export interface Span {
+  href?: string;
   text: string;
-}
-
-export interface Plain extends SpanBase {
-  type: 'plain';
-}
-
-export interface Link extends SpanBase {
-  type: 'link';
-  href: string;
 }
 
 export const parseSpans = (input: string): Span[] => {
@@ -25,7 +14,6 @@ export const parseSpans = (input: string): Span[] => {
     // If the search skipped some plain text or reached end, capture it.
     if (left < right) {
       spans.push({
-        type: 'plain',
         text: input.substring(left, right),
       });
       left = right;
@@ -33,7 +21,6 @@ export const parseSpans = (input: string): Span[] => {
     if (match) {
       const text = match[0];
       spans.push({
-        type: 'link',
         href: text,
         text,
       });

--- a/gui/src/components/logs/parseSpans.ts
+++ b/gui/src/components/logs/parseSpans.ts
@@ -1,31 +1,239 @@
 export interface Span {
   href?: string;
   text: string;
+  forground?: string;
+  background?: string;
+  style?: Style;
 }
 
-export const parseSpans = (input: string): Span[] => {
-  const spans: Span[] = [];
-  //const re = /(?<=^\s\<)https?:\/\/(.+?)(?=$\s\>)/gi;
-  const re = /(^|(?<=[\s<]))https?:\/\/(.+?)($|(?=[\s>]))/gi;
-  let left = 0;
-  while (left < input.length) {
-    const match = re.exec(input);
-    const right = match ? re.lastIndex - match[0].length : input.length;
-    // If the search skipped some plain text or reached end, capture it.
-    if (left < right) {
-      spans.push({
-        text: input.substring(left, right),
-      });
-      left = right;
-    }
-    if (match) {
-      const text = match[0];
-      spans.push({
-        href: text,
-        text,
-      });
-      left += text.length;
-    }
+export type Style =
+  | 'bold'
+  | 'faint'
+  | 'italic'
+  | 'underline'
+  | 'blink'
+  | 'invert'
+  | 'strike';
+
+const isLinkOpenBoundary = (c: string) => {
+  switch (c) {
+    case '':
+    case ' ':
+    case '\n':
+    case '<':
+      return true;
+    default:
+      return false;
   }
+};
+
+const isLinkCloseBoundary = (c: string) => {
+  switch (c) {
+    case '':
+    case ' ':
+    case '\n':
+    case '<':
+      return true;
+    default:
+      return false;
+  }
+};
+
+const standardColors: string[] = [
+  'rgb(0, 0, 0)', // Black
+  'rgb(170, 0, 0)', // Red
+  'rgb(0, 170, 0)', // Green
+  'rgb(170, 85, 0)', // Yellow
+  'rgb(0, 0, 170)', // Blue
+  'rgb(170, 0, 170)', // Magenta
+  'rgb(0, 170, 170)', // Cyan
+  'rgb(170, 170, 170)', // White
+];
+
+const brightColors: string[] = [
+  'rgb(85, 85, 85)', // Gray
+  'rgb(255, 85, 85)', // Red
+  'rgb(85, 255, 85)', // Green
+  'rgb(255, 255, 85)', // Yellow
+  'rgb(85, 85, 255)', // Blue
+  'rgb(255, 85, 255)', // Magenta
+  'rgb(85, 255, 255)', // Cyan
+  'rgb(255, 255, 255)', // White
+];
+
+const lookupColor256 = (i: number): string => {
+  if (i < 0) {
+    return '#000000';
+  }
+  if (i < 8) {
+    return standardColors[i];
+  }
+  if (i < 16) {
+    return brightColors[i - 8];
+  }
+  if (i < 232) {
+    // Color cube of size 6.
+    // TODO: Does this produce the correct colors?
+    const x = i - 16;
+    const r = ((x >> 4) % 6) * 51;
+    const g = ((x >> 2) % 6) * 51;
+    const b = ((x >> 0) % 6) * 51;
+    return `rgb(${r},${g},${b})`;
+  }
+  if (i < 256) {
+    // Grayscale.
+    const x = ((i - 232) / 24) * 256;
+    return `rgb(${x}, ${x}, ${x})`;
+  }
+  return '000000';
+};
+
+const lookupColor24bit = (codes: number[]): string => {
+  const r = 200;
+  const g = 200;
+  const b = 200;
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+const lookupColor = (codes: number[]) => {
+  switch (codes[1]) {
+    case 5:
+      return lookupColor256(codes[2]);
+    case 2:
+      return lookupColor24bit(codes);
+    default:
+      return '000000';
+  }
+};
+
+export const parseSpans = (input: string): Span[] => {
+  // TODO: Create reusable state machine so that multiple independent lines
+  // can have persistent color styles across lines.
+  let forground: string | null = null;
+  let background: string | null = null;
+  let style: Style | null = null;
+  let inLink = false;
+  let href = '';
+  let text = '';
+
+  const spans: Span[] = [];
+
+  const emitSpan = () => {
+    if (text.length > 0) {
+      const span: Span = {
+        text,
+      };
+      const setOptional = <TKey extends keyof Span>(
+        key: TKey,
+        value: Span[TKey] | null,
+      ) => {
+        if (value) {
+          span[key] = value;
+        }
+      };
+      setOptional('href', href);
+      setOptional('forground', forground);
+      setOptional('background', background);
+      setOptional('style', style);
+      spans.push(span);
+      text = '';
+    }
+  };
+
+  let pos = 0;
+  let prev = '';
+  while (pos <= input.length) {
+    const cur = pos === input.length ? '' : input[pos];
+    const rest = input.slice(pos);
+
+    // End the current link?
+    if (inLink) {
+      const endOfLink = isLinkCloseBoundary(cur);
+      if (endOfLink) {
+        href = text;
+        emitSpan();
+        href = '';
+        inLink = false;
+      }
+    }
+
+    // Start a new link?
+    if (!inLink && isLinkOpenBoundary(prev) && /^https?:\/\//i.test(rest)) {
+      emitSpan();
+      inLink = true;
+    }
+
+    // Handle control sequences.
+    const control = rest.match(/^\u001b\[([\d;]+)m/);
+    if (control) {
+      emitSpan();
+      let codes = control[1].split(';').map((n) => parseInt(n, 10));
+      if (codes.length === 0) {
+        codes = [0];
+      }
+      const command = codes[0];
+      switch (command) {
+        case 0: {
+          // Reset.
+          forground = null;
+          background = null;
+          style = null;
+          break;
+        }
+
+        case 1:
+          style = 'bold';
+          break;
+        case 2:
+          style = 'faint';
+          break;
+        case 3:
+          style = 'italic';
+          break;
+        case 4:
+          style = 'underline';
+          break;
+        case 5:
+        case 6:
+          style = 'blink';
+          break;
+        case 7:
+          style = 'invert';
+          break;
+        case 9:
+          style = 'strike';
+          break;
+
+        case 38:
+          forground = lookupColor(codes);
+          break;
+        case 48:
+          background = lookupColor(codes);
+          break;
+
+        default: {
+          if (30 <= command && command <= 37) {
+            forground = standardColors[command - 30];
+          } else if (40 <= command && command <= 47) {
+            background = standardColors[command - 40];
+          } else if (90 <= command && command <= 97) {
+            forground = brightColors[command - 90];
+          } else if (100 <= command && command <= 107) {
+            background = brightColors[command - 100];
+          }
+        }
+      }
+      pos += control[0].length;
+    } else {
+      text += cur;
+      pos += 1;
+    }
+
+    prev = cur;
+  }
+
+  // Flush.
+  emitSpan();
+
   return spans;
 };

--- a/gui/src/components/logs/parseSpans.ts
+++ b/gui/src/components/logs/parseSpans.ts
@@ -1,7 +1,7 @@
 export interface Span {
   href?: string;
   text: string;
-  forground?: string;
+  foreground?: string;
   background?: string;
   style?: Style;
 }
@@ -109,7 +109,7 @@ const lookupColor = (codes: number[]) => {
 export const parseSpans = (input: string): Span[] => {
   // TODO: Create reusable state machine so that multiple independent lines
   // can have persistent color styles across lines.
-  let forground: string | null = null;
+  let foreground: string | null = null;
   let background: string | null = null;
   let style: Style | null = null;
   let inLink = false;
@@ -132,7 +132,7 @@ export const parseSpans = (input: string): Span[] => {
         }
       };
       setOptional('href', href);
-      setOptional('forground', forground);
+      setOptional('foreground', foreground);
       setOptional('background', background);
       setOptional('style', style);
       spans.push(span);
@@ -175,7 +175,7 @@ export const parseSpans = (input: string): Span[] => {
       switch (command) {
         case 0: {
           // Reset.
-          forground = null;
+          foreground = null;
           background = null;
           style = null;
           break;
@@ -205,7 +205,7 @@ export const parseSpans = (input: string): Span[] => {
           break;
 
         case 38:
-          forground = lookupColor(codes);
+          foreground = lookupColor(codes);
           break;
         case 48:
           background = lookupColor(codes);
@@ -213,11 +213,11 @@ export const parseSpans = (input: string): Span[] => {
 
         default: {
           if (30 <= command && command <= 37) {
-            forground = standardColors[command - 30];
+            foreground = standardColors[command - 30];
           } else if (40 <= command && command <= 47) {
             background = standardColors[command - 40];
           } else if (90 <= command && command <= 97) {
-            forground = brightColors[command - 90];
+            foreground = brightColors[command - 90];
           } else if (100 <= command && command <= 107) {
             background = brightColors[command - 100];
           }

--- a/gui/src/lib/arrays.ts
+++ b/gui/src/lib/arrays.ts
@@ -1,0 +1,1 @@
+export const range = (n: number): number[] => [...Array(n).keys()];


### PR DESCRIPTION
Fixes #123 

This adds basic virtual terminal font attribute parsing logic to the FormattedLogMessage component.

See in Storybook:

![image](https://user-images.githubusercontent.com/119164/128948658-52f8c85d-17a6-4f81-870b-47914af29436.png)
![image](https://user-images.githubusercontent.com/119164/128948687-bce01896-ae82-4617-9c34-a22145ffa0f9.png)
![image](https://user-images.githubusercontent.com/119164/128948696-6681da6f-e9ef-4212-9dfb-29093cbfb65c.png)
![image](https://user-images.githubusercontent.com/119164/128948706-bbb6f15a-63a2-4be3-b648-6f8da1fd334c.png)
![image](https://user-images.githubusercontent.com/119164/128948716-8ba6f757-9f52-400a-aff9-eb353501de8e.png)

And in the app:
![image](https://user-images.githubusercontent.com/119164/128948884-ec1724f1-137a-4315-9a96-b2f951ccff0e.png)
