### PR TITLE
bump max log message length to 1 MiB

### DIFF
--- a/internal/logd/api/consts.go
+++ b/internal/logd/api/consts.go
@@ -1,3 +1,6 @@
 package api
 
-const MaxMessageSize = 1024 // Includes space for newline terminator.
+// Max length of log messages. Size chosen to fit within a UDP packet (max size
+// 64k) and reserve space for Syslog event headers. The message itself always
+// includes a newline terminator as well.
+const MaxMessageSize = 48 * 1024


### PR DESCRIPTION
Fixes #126

Though will probably introduce a follow-up issue that long log lines perform badly :-P 