### PR TITLE
New volume and network

### DIFF
--- a/cmd/exo/new_network.go
+++ b/cmd/exo/new_network.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/deref/exo/internal/core/api"
+	"github.com/deref/exo/internal/providers/docker/components/network"
+	"github.com/deref/exo/internal/util/yamlutil"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	newCmd.AddCommand(newNetworkCmd)
+	// TODO: Options from docker to consider adding support for:
+	//	--attachable           Enable manual container attachment
+	//	--aux-address map      Auxiliary IPv4 or IPv6 addresses used by Network driver (default map[])
+	//	--config-from string   The network from which to copy the configuration
+	//	--config-only          Create a configuration only network
+	//-d, --driver string        Driver to manage the Network (default "bridge")
+	//	--gateway strings      IPv4 or IPv6 Gateway for the master subnet
+	//	--ingress              Create swarm routing-mesh network
+	//	--internal             Restrict external access to the network
+	//	--ip-range strings     Allocate container ip from a sub-range
+	//	--ipam-driver string   IP Address Management Driver (default "default")
+	//	--ipam-opt map         Set IPAM driver specific options (default map[])
+	//	--ipv6                 Enable IPv6 networking
+	//	--label list           Set metadata on a network
+	//-o, --opt map              Set driver specific options (default map[])
+	//	--scope string         Control the network's scope
+	//	--subnet strings       Subnet in CIDR format that represents a network segment
+}
+
+var networkSpec network.Spec
+
+var newNetworkCmd = &cobra.Command{
+	Use:   "network <name> [options]",
+	Short: "Creates a new network",
+	Long: `Creates a new network.
+
+Similar in spirit to:
+
+docker network create <name>
+`,
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := newContext()
+		ensureDaemon()
+		cl := newClient()
+		workspace := requireWorkspace(ctx, cl)
+
+		name := args[0]
+
+		output, err := workspace.CreateComponent(ctx, &api.CreateComponentInput{
+			Name: name,
+			Type: "network",
+			Spec: yamlutil.MustMarshalString(networkSpec),
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(output.ID)
+		return nil
+	},
+}

--- a/cmd/exo/new_volume.go
+++ b/cmd/exo/new_volume.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/deref/exo/internal/core/api"
+	"github.com/deref/exo/internal/providers/docker/components/volume"
+	"github.com/deref/exo/internal/util/yamlutil"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	newCmd.AddCommand(newVolumeCmd)
+	// TODO: Options from docker to consider adding support for:
+	// -d, --driver string   Specify volume driver name (default "local")
+	// --label list      Set metadata for a volume
+	// -o, --opt map         Set driver specific options (default map[])
+}
+
+var volumeSpec volume.Spec
+
+var newVolumeCmd = &cobra.Command{
+	Use:   "volume <name> [options]",
+	Short: "Creates a new volume",
+	Long: `Creates a new volume.
+
+Similar in spirit to:
+
+docker volume create <name>
+`,
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := newContext()
+		ensureDaemon()
+		cl := newClient()
+		workspace := requireWorkspace(ctx, cl)
+
+		name := args[0]
+
+		output, err := workspace.CreateComponent(ctx, &api.CreateComponentInput{
+			Name: name,
+			Type: "volume",
+			Spec: yamlutil.MustMarshalString(volumeSpec),
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(output.ID)
+		return nil
+	},
+}


### PR DESCRIPTION
Absolute minimum versions of `exo new network` and `exo new volume`. Both of which take no options, and that's OK. Added some `TODO` blocks to document the command line flags supported by docker's respective `docker network create` and `docker volume create` commands.