### PR TITLE
Reset terminal colors between log lines.

### DIFF
--- a/cmd/exo/logs.go
+++ b/cmd/exo/logs.go
@@ -106,7 +106,7 @@ func tailLogs(ctx context.Context, workspace api.Workspace, logRefs []string) er
 				prefix = timestamp
 			}
 
-			fmt.Printf("%s %s\n", prefix, event.Message)
+			fmt.Printf("%s %s%s\n", prefix, event.Message, termReset)
 		}
 		in.Cursor = &output.NextCursor
 		if len(output.Items) < 10 { // TODO: OK heuristic?
@@ -161,3 +161,5 @@ type Color struct {
 func (c Color) IsBlack() bool {
 	return c.Red == 0 && c.Green == 0 && c.Blue == 0
 }
+
+const termReset = "\u001b[0"


### PR DESCRIPTION
Fixes #138

Note that this means that colors can't span multiple log lines. That
restriction is reasonable, however, because without it, you'd have to
perform an unbounded amount of scroll-back to find control codes.