### PR TITLE
Fix error when there is no procfile

### DIFF
--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -768,6 +768,9 @@ func (ws *Workspace) ReadFile(ctx context.Context, input *api.ReadFileInput) (*a
 
 	content, err := os.ReadFile(resolvedPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This was causing issues when we were checking for a procfile that didn't exist. https://github.com/deref/exo/blob/4153e65d0f8370ed698ae263085578eab9a70653/gui/src/components/ProcessList.svelte#L62-L67