### PR TITLE
Clean exod shutdown

### DIFF
--- a/cmd/exo/apply.go
+++ b/cmd/exo/apply.go
@@ -47,7 +47,7 @@ var applyCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 
 		cl := newClient()
 		kernel := cl.Kernel()

--- a/cmd/exo/control.go
+++ b/cmd/exo/control.go
@@ -10,7 +10,7 @@ type controlFunc func(ctx context.Context, ws api.Workspace, refs []string) (job
 
 func controlComponents(args []string, f controlFunc) error {
 	ctx := newContext()
-	ensureDaemon()
+	checkOrEnsureServer()
 	cl := newClient()
 	kernel := cl.Kernel()
 	workspace := requireWorkspace(ctx, cl)

--- a/cmd/exo/daemon.go
+++ b/cmd/exo/daemon.go
@@ -39,6 +39,26 @@ var runState struct {
 	URL string `json:"url"`
 }
 
+// checkOrEnsureServer is intended to be used by the CLI commands that do not explicitly start a server.
+// It will first check whether a server is running, and if it is not, the behaviour depends on whether
+// a URL is configured for the exo client or not:
+// - If a URL is configured, this fails since the server is not available.
+// - If no URL is configured, this attempts to start a server and exits with an error if it cannot.
+// The assumption is that if a URL is configured, the client should not try to start a local instance. One
+// implication of this is that if you are running a local server on a non-default port, you will need to
+// explicitly run one of the following commands to explicitly start a server: `exo daemon`, `exo server`,
+// `exo run`.
+func checkOrEnsureServer() {
+	if checkHealthy() {
+		return
+	}
+	if cfg.Client.URL == "" {
+		ensureDaemon()
+		return
+	}
+	cmdutil.Fatalf("the server at %q is not healthy", cfg.Client.URL)
+}
+
 func ensureDaemon() {
 	// Validate exod process record.
 	err := loadRunState()
@@ -92,7 +112,7 @@ func ensureDaemon() {
 	// Cleanup if unhealthy.
 	if !ok {
 		cmdutil.Warnf("daemon not healthy")
-		killExod()
+		osutil.TerminateProcessWithTimeout(os.Getpid(), time.Second*5)
 		os.Exit(1)
 	}
 }

--- a/cmd/exo/daemon.go
+++ b/cmd/exo/daemon.go
@@ -112,7 +112,7 @@ func ensureDaemon() {
 	// Cleanup if unhealthy.
 	if !ok {
 		cmdutil.Warnf("daemon not healthy")
-		osutil.TerminateProcessWithTimeout(os.Getpid(), time.Second*5)
+		osutil.TerminateProcessWithTimeout(runState.Pid, time.Second*5)
 		os.Exit(1)
 	}
 }

--- a/cmd/exo/dispose.go
+++ b/cmd/exo/dispose.go
@@ -16,7 +16,7 @@ var disposeCmd = &cobra.Command{
 	Hidden: true, // This command is only really useful for testing controllers.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
 		workspace := requireWorkspace(ctx, cl)

--- a/cmd/exo/exit.go
+++ b/cmd/exo/exit.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"time"
 
-	"github.com/deref/exo/internal/util/osutil"
+	"github.com/deref/exo/internal/core/api"
+	"github.com/deref/exo/internal/util/cmdutil"
 	"github.com/spf13/cobra"
 )
 
@@ -19,20 +18,14 @@ var exitCmd = &cobra.Command{
 	Long:  `Stop the exo daemon process.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		loadRunState()
-		if runState.Pid == 0 {
-			return nil
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+		_, err := cl.Kernel().Exit(ctx, &api.ExitInput{})
+		if err != nil {
+			cmdutil.Fatalf("exiting: %w", err)
 		}
-
-		return killExod()
+		fmt.Println("Ok")
+		return nil
 	},
-}
-
-func killExod() error {
-	_ = osutil.TerminateProcessWithTimeout(runState.Pid, 5*time.Second)
-
-	if err := os.Remove(cfg.RunStateFile); err != nil {
-		return fmt.Errorf("removing run state file: %w", err)
-	}
-	return nil
 }

--- a/cmd/exo/exit.go
+++ b/cmd/exo/exit.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/deref/exo/internal/core/api"
 	"github.com/deref/exo/internal/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -25,7 +23,6 @@ var exitCmd = &cobra.Command{
 		if err != nil {
 			cmdutil.Fatalf("exiting: %w", err)
 		}
-		fmt.Println("Ok")
 		return nil
 	},
 }

--- a/cmd/exo/gui.go
+++ b/cmd/exo/gui.go
@@ -24,7 +24,7 @@ If the current directory is part of a workspace, navigates to it.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 
 		cwd := cmdutil.MustGetwd()

--- a/cmd/exo/job_tree.go
+++ b/cmd/exo/job_tree.go
@@ -25,7 +25,7 @@ var jobTreeCmd = &cobra.Command{
 If job-ids are provided, lists all jobs`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
 

--- a/cmd/exo/job_watch.go
+++ b/cmd/exo/job_watch.go
@@ -25,7 +25,7 @@ var jobWatchCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
 

--- a/cmd/exo/logs.go
+++ b/cmd/exo/logs.go
@@ -27,7 +27,7 @@ var logsCmd = &cobra.Command{
 If refs are provided, filters for the logs of those processes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 

--- a/cmd/exo/ls.go
+++ b/cmd/exo/ls.go
@@ -25,7 +25,7 @@ var lsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 		output, err := workspace.DescribeComponents(ctx, &api.DescribeComponentsInput{

--- a/cmd/exo/new_container.go
+++ b/cmd/exo/new_container.go
@@ -144,7 +144,7 @@ exo flags and options for your docker container command.
 	Args:                  cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 

--- a/cmd/exo/new_network.go
+++ b/cmd/exo/new_network.go
@@ -45,7 +45,7 @@ docker network create <name>
 	Args:                  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 

--- a/cmd/exo/new_process.go
+++ b/cmd/exo/new_process.go
@@ -37,7 +37,7 @@ before the program name.
 	Args:                  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 

--- a/cmd/exo/new_volume.go
+++ b/cmd/exo/new_volume.go
@@ -32,7 +32,7 @@ docker volume create <name>
 	Args:                  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 

--- a/cmd/exo/ps.go
+++ b/cmd/exo/ps.go
@@ -20,7 +20,7 @@ var psCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)
 		output, err := workspace.DescribeProcesses(ctx, &api.DescribeProcessesInput{})

--- a/cmd/exo/rm.go
+++ b/cmd/exo/rm.go
@@ -18,7 +18,7 @@ var rmCmd = &cobra.Command{
 			return nil
 		}
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
 		workspace := requireWorkspace(ctx, cl)

--- a/cmd/exo/uninstall.go
+++ b/cmd/exo/uninstall.go
@@ -29,7 +29,7 @@ for manual uninstall instructions.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 
 		cl := newClient()
 
@@ -47,10 +47,11 @@ for manual uninstall instructions.`,
 		}
 
 		// Exit daemon.
-		if err := killExod(); err != nil {
-			fmt.Println("exiting daemon")
-			return fmt.Errorf("exiting daemon: %w", err)
-		}
+		// TODO: Replace w/ RPC.
+		// if err := killExod(); err != nil {
+		// 	fmt.Println("exiting daemon")
+		// 	return fmt.Errorf("exiting daemon: %w", err)
+		// }
 
 		// Remove home directory.
 		fmt.Printf("removing home directory: %s\n", cfg.HomeDir)

--- a/cmd/exo/uninstall.go
+++ b/cmd/exo/uninstall.go
@@ -47,11 +47,9 @@ for manual uninstall instructions.`,
 		}
 
 		// Exit daemon.
-		// TODO: Replace w/ RPC.
-		// if err := killExod(); err != nil {
-		// 	fmt.Println("exiting daemon")
-		// 	return fmt.Errorf("exiting daemon: %w", err)
-		// }
+		if _, err := cl.Kernel().Exit(ctx, &api.ExitInput{}); err != nil {
+			cmdutil.Fatalf("exiting daemon: %w", err)
+		}
 
 		// Remove home directory.
 		fmt.Printf("removing home directory: %s\n", cfg.HomeDir)

--- a/cmd/exo/workspace.go
+++ b/cmd/exo/workspace.go
@@ -30,7 +30,7 @@ If no subcommand is given, describes the current workspace.`,
 			return nil
 		}
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 
 		cl := newClient()
 		workspace := requireWorkspace(ctx, cl)

--- a/cmd/exo/workspace_destroy.go
+++ b/cmd/exo/workspace_destroy.go
@@ -19,7 +19,7 @@ Deleting a workspace also deletes all resources in that workspace.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
 		var workspace api.Workspace

--- a/cmd/exo/workspace_init.go
+++ b/cmd/exo/workspace_init.go
@@ -20,7 +20,7 @@ will be rooted at the current working directory.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		var root string
 		if len(args) < 1 {

--- a/cmd/exo/workspace_ls.go
+++ b/cmd/exo/workspace_ls.go
@@ -21,7 +21,7 @@ var workspaceLSCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		ensureDaemon()
+		checkOrEnsureServer()
 		cl := newClient()
 		output, err := cl.Kernel().DescribeWorkspaces(ctx, &api.DescribeWorkspacesInput{})
 		if err != nil {

--- a/internal/core/api/kernel.go
+++ b/internal/core/api/kernel.go
@@ -21,6 +21,8 @@ type Kernel interface {
 	Upgrade(context.Context, *UpgradeInput) (*UpgradeOutput, error)
 	// Checks whether server is up.
 	Ping(context.Context, *PingInput) (*PingOutput, error)
+	// Gracefully shutdown the exo daemon.
+	Exit(context.Context, *ExitInput) (*ExitOutput, error)
 	DescribeTasks(context.Context, *DescribeTasksInput) (*DescribeTasksOutput, error)
 }
 
@@ -75,6 +77,12 @@ type PingInput struct {
 type PingOutput struct {
 }
 
+type ExitInput struct {
+}
+
+type ExitOutput struct {
+}
+
 type DescribeTasksInput struct {
 
 	// If supplied, filters tasks by job.
@@ -106,6 +114,9 @@ func BuildKernelMux(b *josh.MuxBuilder, factory func(req *http.Request) Kernel) 
 	})
 	b.AddMethod("ping", func(req *http.Request) interface{} {
 		return factory(req).Ping
+	})
+	b.AddMethod("exit", func(req *http.Request) interface{} {
+		return factory(req).Exit
 	})
 	b.AddMethod("describe-tasks", func(req *http.Request) interface{} {
 		return factory(req).DescribeTasks

--- a/internal/core/api/kernel.josh.hcl
+++ b/internal/core/api/kernel.josh.hcl
@@ -39,6 +39,10 @@ interface "kernel" {
     doc = "Checks whether server is up."
   }
 
+  method "exit" {
+    doc = "Gracefully shutdown the exo daemon."
+  }
+
   method "describe-tasks" {
     input "job-ids" "[]string" {
       doc = "If supplied, filters tasks by job."

--- a/internal/core/client/kernel.go
+++ b/internal/core/client/kernel.go
@@ -56,6 +56,11 @@ func (c *Kernel) Ping(ctx context.Context, input *api.PingInput) (output *api.Pi
 	return
 }
 
+func (c *Kernel) Exit(ctx context.Context, input *api.ExitInput) (output *api.ExitOutput, err error) {
+	err = c.client.Invoke(ctx, "exit", input, &output)
+	return
+}
+
 func (c *Kernel) DescribeTasks(ctx context.Context, input *api.DescribeTasksInput) (output *api.DescribeTasksOutput, err error) {
 	err = c.client.Invoke(ctx, "describe-tasks", input, &output)
 	return

--- a/internal/core/server/kernel.go
+++ b/internal/core/server/kernel.go
@@ -118,12 +118,10 @@ func (kern *Kernel) Ping(context.Context, *api.PingInput) (*api.PingOutput, erro
 }
 
 func (kern *Kernel) Exit(context.Context, *api.ExitInput) (*api.ExitOutput, error) {
-	// Return immediately, then asynchronously try to shutdown.
-	defer func() {
-		go func() {
-			ownPid := os.Getpid()
-			_ = osutil.TerminateProcessWithTimeout(ownPid, 5*time.Second)
-		}()
+	// Return immediately, shutdown asynchronously.
+	go func() {
+		ownPid := os.Getpid()
+		_ = osutil.TerminateProcessWithTimeout(ownPid, 5*time.Second)
 	}()
 
 	return &api.ExitOutput{}, nil

--- a/internal/logd/logd.go
+++ b/internal/logd/logd.go
@@ -5,14 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path/filepath"
 	"time"
 
 	"github.com/deref/exo/internal/chrono"
-	"github.com/deref/exo/internal/gensym"
 	"github.com/deref/exo/internal/logd/api"
 	"github.com/deref/exo/internal/logd/server"
-	"github.com/deref/exo/internal/logd/store/badger"
 	"github.com/deref/exo/internal/util/logging"
 	"github.com/influxdata/go-syslog/v3"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
@@ -20,23 +17,11 @@ import (
 
 type Service struct {
 	Logger     logging.Logger
-	VarDir     string
 	SyslogPort uint
 	server.LogCollector
 }
 
 func (svc *Service) Run(ctx context.Context) error {
-	logsDir := filepath.Join(svc.VarDir, "logs")
-
-	store, err := badger.Open(ctx, svc.Logger, logsDir)
-	if err != nil {
-		return fmt.Errorf("opening store: %w", err)
-	}
-	defer store.Close()
-
-	svc.IDGen = gensym.NewULIDGenerator(ctx)
-	svc.Store = store
-
 	addr := fmt.Sprintf(":%d", svc.SyslogPort)
 	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {

--- a/internal/util/cmdutil/http.go
+++ b/internal/util/cmdutil/http.go
@@ -20,7 +20,7 @@ func ListenAndServe(ctx context.Context, svr *http.Server) {
 		ShutdownOnInterrupt(ctx, svr)
 		return nil
 	})
-	if err := eg.Wait(); err != nil {
+	if err := eg.Wait(); err != nil && err != http.ErrServerClosed {
 		Fatal(err)
 	}
 }


### PR DESCRIPTION
Now that the process will try to exit cleanly on sigterm, this moves the code for sending the server a sigterm from the client and into the server itself. `exo exit` then becomes an RPC call that instructs the server to try to terminate itself. This also changes a lot of the CLI commands to not attempt to start a daemon if a `client.url` is present in the config file.

Fixes #148 