### PR TITLE
Use CSS variables app-wide and clean up styling code

### DIFF
--- a/gui/public/globals.css
+++ b/gui/public/globals.css
@@ -5,8 +5,8 @@
 
 :root {
   font-family: var(--font-sans);
-  color: var(--color);
-  background-color: var(--bg-color);
+  color: var(--primary-color);
+  background-color: var(--primary-bg-color);
 }
 
 * {

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -18,6 +18,7 @@
 /* Theme color variables */
 
 :root {
+  --primary-color: #000000;
   --strong-color: #000000;
   --grey-1-color: #111111;
   --grey-2-color: #222222;
@@ -33,17 +34,28 @@
   --grey-c-color: #cccccc;
   --grey-d-color: #dddddd;
   --grey-e-color: #eeeeee;
+  --grey-e7-color: #e7e7e7;
+  --grey-f9-color: #f9f9f9;
   --layout-bg-color: #cccccc;
+  --secondary-bg-color: #f5f5f5;
+  --primary-bg-color: #ffffff;
+  /* Contextual color */
+  --error-color: #ee0000;
+  --link-color: #0066ee;
+  /* Nav */
   --nav-bg-color: #e7e7e7;
   --nav-button-active-bg-color: #d5d5d5;
   --nav-button-active-hover-bg-color: #cccccc;
-  --secondary-bg-color: #f5f5f5;
-  --primary-bg-color: #ffffff;
   --dev-mode-bg-color: #007bd4;
   --dev-mode-color: #ffffff;
-  --icon-button-bg-color: #77777700;
-  --icon-button-hover-bg-color: #77777711;
-  --icon-button-focus-bg-color: #77777733;
+  /* Code */
+  --code-bg-color: #44444411;
+  --code-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 9px -4px #00000033,
+    0 0.4px 0 0.8px #0000001a;
+  /* Process details */
+  --sparkline-stroke: #ee0000;
+  --sparkline-fill: #ee000044;
+  /* Spinners */
   --spinner-grey-t: #66666633;
   --spinner-grey-r: #66666677;
   --spinner-grey-b: #666666bb;
@@ -52,8 +64,35 @@
   --spinner-blue-r: #007bd477;
   --spinner-blue-b: #007bd4bb;
   --spinner-blue-l: #007bd4ff;
-  --heavy-3d-box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-    0 8px 12px -6px rgba(0, 0, 0, 0.3), 0 0.5px 0 1px rgba(0, 0, 0, 0.2);
+  /* Checkbox */
+  --checkbox-color: #777777ff;
+  --checkbox-bg-color: #77777700;
+  --checkbox-border-color: #77777777;
+  --checkbox-hover-color: #444444;
+  --checkbox-hover-bg-color: #77777711;
+  --checkbox-focus-bg-color: #77777722;
+  --checkbox-active-hover-bg-color: #55ccff22;
+  --checkbox-active-focus-bg-color: #55ccff44;
+  --checkbox-active-color: #008ac5;
+  --checkbox-active-border-color: #008ac577;
+  /* Buttons */
+  --icon-button-bg-color: #77777700;
+  --icon-button-hover-bg-color: #77777711;
+  --icon-button-focus-bg-color: #77777733;
+  --button-background: linear-gradient(#fff, #f5f5f5);
+  --button-hover-background: linear-gradient(#fafafa, #e7e7e7);
+  --button-active-background: linear-gradient(#f7f7f7, #e0e0e0);
+  --button-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 8px -3px #00000026,
+    0 0.4px 0 0.8px #00000040;
+  --button-hover-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 8px -4px #00000033,
+    0 0.4px 0 0.8px #00000059;
+  --button-active-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 6px -3px #00000026,
+    0 0.4px 0 0.8px #00000073;
+  /* Shadows */
+  --heavy-3d-box-shadow: 0 0.33px 0 1px #ffffff26, 0 8px 12px -6px #0000004d,
+    0 0.5px 0 1px #00000033;
+  --text-input-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 9px -4px #0000001a inset,
+    0 0.4px 0 0.8px #0000001a inset;
 }
 
 /* @media (prefers-color-scheme: dark) {

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -76,9 +76,9 @@
   --checkbox-active-color: #008ac5;
   --checkbox-active-border-color: #008ac577;
   /* Buttons */
-  --icon-button-bg-color: #77777700;
-  --icon-button-hover-bg-color: #77777711;
-  --icon-button-focus-bg-color: #77777733;
+  --icon-button-bg-color: #00000000;
+  --icon-button-hover-bg-color: #00000010;
+  --icon-button-focus-bg-color: #00000018;
   --button-background: linear-gradient(#fff, #f5f5f5);
   --button-hover-background: linear-gradient(#fafafa, #e7e7e7);
   --button-active-background: linear-gradient(#f7f7f7, #e0e0e0);

--- a/gui/src/components/Button.svelte
+++ b/gui/src/components/Button.svelte
@@ -13,12 +13,11 @@
 
 <style>
   button {
-    background: linear-gradient(#fff, #f5f5f5);
     border: none;
     border-radius: 5px;
     padding: 12px 18px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 4px 8px -3px rgba(0, 0, 0, 0.15), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.25);
+    background: var(--button-background);
+    box-shadow: var(--button-shadow);
   }
 
   .small {
@@ -26,14 +25,12 @@
   }
 
   button:hover {
-    background: linear-gradient(#fafafa, #e7e7e7);
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 8px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.35);
+    background: var(--button-hover-background);
+    box-shadow: var(--button-hover-shadow);
   }
 
   button:active {
-    background: linear-gradient(#f7f7f7, #e0e0e0);
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 4px 6px -3px rgba(0, 0, 0, 0.15), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.45);
+    background: var(--button-active-background);
+    box-shadow: var(--button-active-shadow);
   }
 </style>

--- a/gui/src/components/CheckboxButton.svelte
+++ b/gui/src/components/CheckboxButton.svelte
@@ -25,10 +25,10 @@
     width: 22px;
     height: 22px;
     padding: 0;
-    color: #777777;
-    background-color: #77777700;
+    color: var(--checkbox-color);
+    background-color: var(--checkbox-bg-color);
+    border: 1px solid var(--checkbox-border-color);
     border-radius: 4px;
-    border: 1px solid #77777777;
     outline: none;
     margin-left: 4px;
     display: flex;
@@ -49,7 +49,7 @@
   }
 
   button.active {
-    border-color: #008ac577;
+    border-color: var(--checkbox-active-border-color);
   }
 
   button :global(svg),
@@ -59,23 +59,23 @@
 
   button.active :global(svg),
   button.active :global(svg *) {
-    fill: #008ac5;
+    fill: var(--checkbox-active-color);
   }
 
   button:hover {
-    background-color: #77777711;
-    color: #444444;
+    background-color: var(--checkbox-hover-bg-color);
+    color: var(--checkbox-hover-color);
   }
 
   button.active:hover {
-    background-color: #55ccff22;
+    background-color: var(--checkbox-active-hover-bg-color);
   }
 
   button:focus {
-    background-color: #77777722;
+    background-color: var(--checkbox-focus-bg-color);
   }
 
   button.active:focus {
-    background-color: #55ccff44;
+    background-color: var(--checkbox-active-focus-bg-color);
   }
 </style>

--- a/gui/src/components/CheckeredTableWrapper.svelte
+++ b/gui/src/components/CheckeredTableWrapper.svelte
@@ -3,13 +3,13 @@
     as well as some shadowing and general style improvements for enhanced legibility.
 
   Please ensure your table has the structure:
-  * table
-    * thead (optional)
-    * ...tr...
-      * ...th...
-    * tbody
-    * ...tr...
-      * ...td...
+  table
+      thead (optional)
+          ...tr...
+              ...th...
+      tbody
+          ...tr...
+              ...td...
 -->
 
 <div>
@@ -21,8 +21,7 @@
     border: none;
     border-collapse: collapse;
     border-radius: 4px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--heavy-3d-box-shadow);
     overflow: hidden;
   }
 
@@ -33,23 +32,23 @@
   }
 
   div :global(th:nth-child(2n)) {
-    background: #f9f9f9;
+    background: var(--grey-f9-color);
   }
 
   div :global(tbody tr:nth-child(2n + 1)) {
-    background: #eeeeee;
+    background: var(--grey-e-color);
   }
 
   div :global(tbody tr:nth-child(2n)) {
-    background: #ffffff;
+    background: var(--primary-bg-color);
   }
 
   div :global(tbody tr:nth-child(2n + 1) td:nth-child(2n)) {
-    background: #e7e7e7;
+    background: var(--grey-e7-color);
   }
 
   div :global(tbody tr:nth-child(2n) td:nth-child(2n)) {
-    background: #f9f9f9;
+    background: var(--grey-f9-color);
   }
 
   div :global(tr:first-child > *) {

--- a/gui/src/components/Code.svelte
+++ b/gui/src/components/Code.svelte
@@ -2,11 +2,10 @@
 
 <style>
   code {
-    background: rgba(68, 68, 68, 0.0667);
+    background: var(--code-bg-color);
+    box-shadow: var(--code-shadow);
     font-size: 0.85em;
     border-radius: 0.33em;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.1);
     padding: 0.3em 0.45em;
     margin: -4px 0;
   }

--- a/gui/src/components/CodeBlock.svelte
+++ b/gui/src/components/CodeBlock.svelte
@@ -2,10 +2,10 @@
 
 <style>
   pre {
-    background: rgba(68, 68, 68, 0.0667);
+    background: var(--code-bg-color);
+    box-shadow: var(--heavy-3d-box-shadow);
     font-size: 16px;
     border-radius: 0.33em;
     padding: 0.667em 1em;
-    box-shadow: var(--heavy-3d-box-shadow);
   }
 </style>

--- a/gui/src/components/ErrorLabel.svelte
+++ b/gui/src/components/ErrorLabel.svelte
@@ -21,9 +21,9 @@
 
 <style>
   div {
+    color: var(--error-color);
     display: flex;
     align-items: center;
-    color: red;
   }
 
   span {

--- a/gui/src/components/IconButton.svelte
+++ b/gui/src/components/IconButton.svelte
@@ -26,8 +26,8 @@
   }
 
   button:hover {
-    background-color: var(--icon-button-hover-bg-color);
     color: var(--grey-3-color);
+    background-color: var(--icon-button-hover-bg-color);
   }
 
   button:focus {

--- a/gui/src/components/Link.svelte
+++ b/gui/src/components/Link.svelte
@@ -11,5 +11,7 @@
       router.push(href);
       event.preventDefault();
     }
-  }}><slot /></a
+  }}
 >
+  <slot />
+</a>

--- a/gui/src/components/LogsViewer.svelte
+++ b/gui/src/components/LogsViewer.svelte
@@ -142,9 +142,9 @@
 
   input {
     width: 100%;
-    background: var(--primary-bg-color);
     border: none;
     border-top: 1px solid var(--layout-bg-color);
+    background: var(--primary-bg-color);
     font-size: 16px;
     padding: 8px 12px;
     outline: none;

--- a/gui/src/components/Textarea.svelte
+++ b/gui/src/components/Textarea.svelte
@@ -12,9 +12,7 @@
     border: none;
     border-radius: 4px;
     padding: 12px 18px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.1) inset,
-      0 0.4px 0 0.8px rgba(0, 0, 0, 0.1) inset;
+    box-shadow: var(--text-input-shadow);
     width: 100%;
     height: 120px;
     resize: vertical;

--- a/gui/src/components/Textbox.svelte
+++ b/gui/src/components/Textbox.svelte
@@ -13,9 +13,7 @@
     border: none;
     border-radius: 4px;
     padding: 12px 18px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 9px -4px rgba(0, 0, 0, 0.1) inset,
-      0 0.4px 0 0.8px rgba(0, 0, 0, 0.1) inset;
+    box-shadow: var(--text-input-shadow);
     width: var(--input-width);
   }
 </style>

--- a/gui/src/components/logs/FormattedLogMessage.svelte
+++ b/gui/src/components/logs/FormattedLogMessage.svelte
@@ -68,26 +68,21 @@
   }
 
   @keyframes blink {
-    0% {
-      visibility: hidden;
+    from {
+      opacity: 0;
+    }
+    49% {
+      opacity: 0;
     }
     50% {
-      visibility: hidden;
+      opacity: 1;
     }
-    100% {
-      visibility: visible;
+    to {
+      opacity: 1;
     }
   }
 
   :global(.exo-message-invert) {
-    background: white;
     filter: invert(1);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :global(.exo-message-invert) {
-      background: black;
-      filter: invert(1);
-    }
   }
 </style>

--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -26,6 +26,7 @@
 
 <style>
   table {
+    background: var(--primary-bg-color);
     font-family: var(--font-mono);
     font-variant-ligatures: var(--preferred-ligatures-logs);
     font-weight: 450;
@@ -42,13 +43,13 @@
   td {
     padding: 0 0.3em;
     vertical-align: text-top;
-    color: #333333;
+    color: var(--grey-3-color);
     white-space: pre-wrap;
   }
 
   tr:hover td {
-    background: #f3f3f3;
-    color: #111111;
+    background: var(--grey-e-color);
+    color: var(--grey-1-color);
   }
 
   .name {
@@ -63,12 +64,11 @@
   }
 
   .time {
-    color: #999999;
+    color: var(--grey-9-color);
     cursor: zoom-in;
   }
 
   tr:hover .time {
-    background: #eeeeee;
-    color: #555555;
+    color: var(--grey-5-color);
   }
 </style>

--- a/gui/src/pages/Home.svelte
+++ b/gui/src/pages/Home.svelte
@@ -54,19 +54,16 @@
     padding: 0;
     display: grid;
     gap: 16px;
-    grid-template-columns: repeat(
-      auto-fill,
-      minmax(320px, 1fr)
-    ); /* Auto-responsive */
+    /* Auto-responsive */
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   }
 
   li {
-    background: linear-gradient(#fff, #f5f5f5);
+    background: var(--button-background);
+    box-shadow: var(--button-shadow);
     border: none;
     border-radius: 4px;
     padding: 16px 24px;
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 4px 8px -3px rgba(0, 0, 0, 0.15), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.25);
     position: relative;
     display: grid;
     grid-template-columns: max-content 2fr;
@@ -85,14 +82,12 @@
   }
 
   li:hover {
-    background: linear-gradient(#fafafa, #e7e7e7);
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 6px 8px -4px rgba(0, 0, 0, 0.2), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.35);
+    background: var(--button-hover-background);
+    box-shadow: var(--button-hover-shadow);
   }
 
   li:active {
-    background: linear-gradient(#f7f7f7, #e0e0e0);
-    box-shadow: 0 0.33px 0 1px hsla(0, 0%, 100%, 0.15),
-      0 4px 6px -3px rgba(0, 0, 0, 0.15), 0 0.4px 0 0.8px rgba(0, 0, 0, 0.45);
+    background: var(--button-active-background);
+    box-shadow: var(--button-active-shadow);
   }
 </style>

--- a/gui/src/pages/NewProcess.svelte
+++ b/gui/src/pages/NewProcess.svelte
@@ -211,7 +211,7 @@ my-app --port 4000
     border: none;
     background: none;
     font-weight: 450;
-    color: #777;
+    color: var(--grey-7-color);
   }
 
   .edit-as button:hover {
@@ -219,8 +219,8 @@ my-app --port 4000
   }
 
   .edit-as .selected {
-    color: #06e;
-    font-weight: 450;
     text-decoration: underline;
+    font-weight: 450;
+    color: var(--link-color);
   }
 </style>

--- a/gui/src/pages/Process.svelte
+++ b/gui/src/pages/Process.svelte
@@ -150,12 +150,6 @@
 </Layout>
 
 <style>
-  .sparkline {
-    stroke: red;
-    fill: none;
-    margin: -6px -15px;
-  }
-
   code {
     width: 100%;
     max-width: 600px;
@@ -168,12 +162,11 @@
   .label {
     font-size: 0.8em;
     font-weight: 450;
-    color: #555555;
+    color: var(--grey-5-color);
   }
-
-  /* line with highlight area */
   .sparkline {
-    stroke: red;
-    fill: rgba(255, 0, 0, 0.3);
+    margin: -6px -15px;
+    stroke: var(--sparkline-stroke);
+    fill: var(--sparkline-fill);
   }
 </style>


### PR DESCRIPTION
This swaps from in-situ coloring to `theme.css` CSS variable coloring app-wide in order to centralize the color palette and facilitate future initiatives:

- Further reduction of specific/repetitive styling, by moving towards a more minimal/efficient palette.
- Basic color theming (light/dark/black)
- Potential advanced user color themes
- Allow high leverage re-coloring at the component/parent level to theme components without replicating excessive styling code