### PR TITLE
InitResource args now passed via newController in ComponentBase

### DIFF
--- a/internal/core/server/controller.go
+++ b/internal/core/server/controller.go
@@ -1,7 +1,7 @@
 package server
 
 type Controller interface {
-	InitResource(componentID, spec, state string) error
+	InitResource() error
 	MarshalState() (state string, err error)
 	IsDeleted() bool
 	MarkDeleted()

--- a/internal/providers/core/component.go
+++ b/internal/providers/core/component.go
@@ -17,6 +17,9 @@ type Component interface {
 
 type ComponentBase struct {
 	ComponentID          string
+	ComponentName        string
+	ComponentSpec        string
+	ComponentState       string
 	WorkspaceRoot        string
 	WorkspaceEnvironment map[string]string
 	Logger               logging.Logger

--- a/internal/providers/core/components/invalid/component.go
+++ b/internal/providers/core/components/invalid/component.go
@@ -4,7 +4,7 @@ type Invalid struct {
 	Err error
 }
 
-func (invalid *Invalid) InitResource(componentID, spec, state string) error {
+func (invalid *Invalid) InitResource() error {
 	return nil
 }
 

--- a/internal/providers/docker/components/container/controller.go
+++ b/internal/providers/docker/components/container/controller.go
@@ -7,12 +7,11 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-func (c *Container) InitResource(componentID, spec, state string) error {
-	c.ComponentID = componentID
-	if err := yaml.Unmarshal([]byte(spec), &c.Spec); err != nil {
+func (c *Container) InitResource() error {
+	if err := yaml.Unmarshal([]byte(c.ComponentSpec), &c.Spec); err != nil {
 		return fmt.Errorf("unmarshalling spec: %w", err)
 	}
-	if err := jsonutil.UnmarshalString(state, &c.State); err != nil {
+	if err := jsonutil.UnmarshalString(c.ComponentState, &c.State); err != nil {
 		return fmt.Errorf("unmarshalling state: %w", err)
 	}
 	return nil

--- a/internal/providers/docker/components/network/controller.go
+++ b/internal/providers/docker/components/network/controller.go
@@ -7,12 +7,12 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-func (n *Network) InitResource(componentID, spec, state string) error {
-	n.ComponentID = componentID
-	if err := yaml.Unmarshal([]byte(spec), &n.Spec); err != nil {
+func (n *Network) InitResource() error {
+	n.ComponentID = n.ComponentID
+	if err := yaml.Unmarshal([]byte(n.ComponentSpec), &n.Spec); err != nil {
 		return fmt.Errorf("unmarshalling spec: %w", err)
 	}
-	if err := jsonutil.UnmarshalString(state, &n.State); err != nil {
+	if err := jsonutil.UnmarshalString(n.ComponentState, &n.State); err != nil {
 		return fmt.Errorf("unmarshalling state: %w", err)
 	}
 	return nil

--- a/internal/providers/docker/components/volume/controller.go
+++ b/internal/providers/docker/components/volume/controller.go
@@ -7,12 +7,11 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-func (v *Volume) InitResource(componentID, spec, state string) error {
-	v.ComponentID = componentID
-	if err := yaml.Unmarshal([]byte(spec), &v.Spec); err != nil {
+func (v *Volume) InitResource() error {
+	if err := yaml.Unmarshal([]byte(v.ComponentSpec), &v.Spec); err != nil {
 		return fmt.Errorf("unmarshalling spec: %w", err)
 	}
-	if err := jsonutil.UnmarshalString(state, &v.State); err != nil {
+	if err := jsonutil.UnmarshalString(v.ComponentState, &v.State); err != nil {
 		return fmt.Errorf("unmarshalling state: %w", err)
 	}
 	return nil

--- a/internal/providers/unix/components/process/controller.go
+++ b/internal/providers/unix/components/process/controller.go
@@ -8,12 +8,11 @@ import (
 	"github.com/deref/exo/internal/util/jsonutil"
 )
 
-func (p *Process) InitResource(componentID, spec, state string) error {
-	p.ComponentID = componentID
-	if err := jsonutil.UnmarshalString(spec, &p.Spec); err != nil {
+func (p *Process) InitResource() error {
+	if err := jsonutil.UnmarshalString(p.ComponentSpec, &p.Spec); err != nil {
 		return fmt.Errorf("unmarshalling spec: %w", err)
 	}
-	if err := jsonutil.UnmarshalString(state, &p.State); err != nil {
+	if err := jsonutil.UnmarshalString(p.ComponentState, &p.State); err != nil {
 		return fmt.Errorf("unmarshalling state: %w", err)
 	}
 	return nil


### PR DESCRIPTION
I wanted component name deeper down in the system (should also be helpful for #192), so I made this refactor.