### PR TITLE
Add CLI completion generate, install, and uninstall.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adhears to [CalVer](./doc/versioning.md).
 
+
+## Unreleased
+
+## Added
+
+- Shell completions.
+
+
 ## 2021-08-31
 
 ### Fixed

--- a/cmd/exo/completion.go
+++ b/cmd/exo/completion.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Hidden:                true,
+	Use:                   "completion",
+	Short:                 "Generate and install shell completions",
+	Long:                  `Generate and install shell completions.`,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
+}

--- a/cmd/exo/completion_generate.go
+++ b/cmd/exo/completion_generate.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	completionCmd.AddCommand(completionGenerateCmd)
+}
+
+var completionGenerateCmd = &cobra.Command{
+	Use:   "generate [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `For automatic installation, see:
+
+	$ exo completion install --help
+
+To load completions:
+
+Bash:
+
+  $ source <(exo completion generate bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ exo completion generate bash > /etc/bash_completion.d/exo
+  # macOS:
+  $ exo completion generate bash > /usr/local/etc/bash_completion.d/exo
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ exo completion generate zsh > "${fpath[1]}/_exo"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ exo completion generate fish | source
+
+  # To load completions for each session, execute once:
+  $ exo completion generate fish > ~/.config/fish/completions/exo.fish
+
+PowerShell:
+
+  PS> exo completion generate powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> exo completion generate powershell > exo.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		completionGenerate(os.Stdout, args[0])
+	},
+}
+
+func completionGenerate(w io.Writer, shell string) {
+	switch shell {
+	case "bash":
+		rootCmd.GenBashCompletion(w)
+	case "zsh":
+		rootCmd.GenZshCompletion(w)
+	case "fish":
+		rootCmd.GenFishCompletion(w, true)
+	case "powershell":
+		rootCmd.GenPowerShellCompletion(w)
+	}
+}

--- a/cmd/exo/completion_install.go
+++ b/cmd/exo/completion_install.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/deref/exo/internal/util/osutil"
+	"github.com/deref/exo/internal/util/which"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	completionCmd.AddCommand(completionInstallCmd)
+}
+
+var completionInstallCmd = &cobra.Command{
+	Use:   "install [bash|zsh|fish|powershell]",
+	Short: "Install shell completions",
+	Args:  cobra.MaximumNArgs(1),
+	Long: `Installs shell completions.
+
+If the shell argument is not provided, it will be inferred from the SHELL
+environment variable.
+
+After running this command, you must restart your shell. Some shells, such as
+zsh, may require additional steps to clear completion caches.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		shell := ""
+		if len(args) > 0 {
+			shell = args[0]
+		}
+
+		if shell == "" {
+			shell = inferShell()
+		}
+		if shell == "" {
+			return errors.New("cannot determine shell")
+		}
+		fmt.Println("inferred shell:", shell)
+
+		var completionPath string
+		for _, candidate := range completionPathCandidates(shell) {
+			dir := filepath.Dir(candidate)
+			if writable, _ := osutil.IsWritable(dir); writable {
+				completionPath = candidate
+				break
+			}
+		}
+
+		if completionPath == "" {
+			return errors.New("cannot infer completion installation path")
+		}
+		f, err := os.Create(completionPath)
+		if err != nil {
+			return fmt.Errorf("creating completion file: %w", err)
+		}
+		defer f.Close()
+		completionGenerate(f, shell)
+
+		fmt.Println("wrote completion script:", completionPath)
+		return nil
+	},
+}
+
+func completionPathCandidates(shell string) []string {
+	var paths []string
+	switch shell {
+	case "bash":
+		paths = []string{
+			completionPathBashLinux,
+			completionPathBashMac,
+		}
+	case "zsh":
+		paths = []string{
+			completionPathZsh(),
+		}
+	case "fish":
+		paths = []string{
+			completionPathFish(),
+		}
+	case "powershell":
+		// TODO: Figure out how to auto-install powershell.
+	}
+
+	// Remove empty string paths.
+	dest := 0
+	for i := 0; i < len(paths); i++ {
+		if paths[i] == "" {
+			continue
+		}
+		paths[dest] = paths[i]
+		dest++
+	}
+	return paths[:dest]
+}
+
+// Returns the path of the current user's default shell.
+func getUserShell() string {
+	sudoUser, _ := os.LookupEnv("SUDO_USER")
+	if sudoUser != "" {
+		// TODO: Query the user's shell from getent or similar on Linux.
+		return ""
+	}
+	shell, _ := os.LookupEnv("SHELL")
+	return shell
+}
+
+// Returns the name of the current user's default shell.
+func inferShell() string {
+	shellPath := getUserShell()
+	for _, shellName := range []string{
+		"bash",
+		"zsh",
+		"fish",
+	} {
+		if strings.HasSuffix(shellPath, "/"+shellName) {
+			return shellName
+		}
+	}
+	// TODO: Detect powershell.
+	return ""
+}
+
+const completionPathBashLinux = "/etc/bash_completion.d/exo"
+const completionPathBashMac = "/usr/local/etc/bash_completion.d/exo"
+
+func completionPathZsh() string {
+	shell := getUserShell()
+	if !strings.HasSuffix(shell, "/zsh") {
+		shell, _ = which.Which("zsh")
+	}
+	if shell == "" {
+		return ""
+	}
+	bs, _ := exec.Command(shell, "-c", `echo "${fpath[1]}/_exo"`).Output()
+	return string(bytes.TrimSpace(bs))
+}
+
+func completionPathFish() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config/fish/completions/exo.fish")
+}

--- a/cmd/exo/completion_uninstall.go
+++ b/cmd/exo/completion_uninstall.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	completionCmd.AddCommand(completionUninstallCmd)
+}
+
+var completionUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstalls shell completions",
+	Long: `Uninstalls shell completions.
+
+If shell is not specified, removes exo shell completion files from all supported
+shells.
+
+After running this command, you must restart your shell. Some shells, such as
+zsh, may require additional steps to clear completion caches.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		shell := ""
+		if len(args) > 0 {
+			shell = args[0]
+		}
+		completionUninstall(shell)
+	},
+}
+
+func completionUninstall(shell string) {
+	var shells []string
+	if shell == "" {
+		shells = completionSupportedShells
+	} else {
+		shells = []string{shell}
+	}
+
+	for _, shell := range shells {
+		for _, candidate := range completionPathCandidates(shell) {
+			removed := os.Remove(candidate) == nil
+			if removed {
+				fmt.Println("removed", candidate)
+			} else {
+				fmt.Println("skipped", candidate)
+			}
+		}
+	}
+}
+
+var completionSupportedShells = []string{
+	"bash",
+	"zsh",
+	"fish",
+	"powershell",
+}

--- a/cmd/exo/uninstall.go
+++ b/cmd/exo/uninstall.go
@@ -33,6 +33,9 @@ for manual uninstall instructions.`,
 
 		cl := newClient()
 
+		shell := "" // All shells.
+		completionUninstall(shell)
+
 		// Destroy workspaces.
 		workspaces, err := cl.Kernel().DescribeWorkspaces(ctx, &api.DescribeWorkspacesInput{})
 		if err != nil {

--- a/doc/install.md
+++ b/doc/install.md
@@ -12,6 +12,10 @@ Grab the latest release from Github: https://github.com/deref/exo/releases
 
 Put the binary `~/.exo/bin` and add that directory to your `PATH`.
 
+### Shell Completions
+
+Shell completion support is available for bash, zsh, fish, and powershell. For installation instructions, run `exo completion --help`.
+
 ## Uninstall
 
 ```bash

--- a/doc/uninstall.md
+++ b/doc/uninstall.md
@@ -8,6 +8,9 @@ exo uninstall
 
 ## Manual Uninstall
 
+If you installed shell completions, reference `exo completion --help` for
+information on relevant install paths for your preferred shell.
+
 Stop supervised processes and free any workspace resources:
 
 ```bash
@@ -34,4 +37,3 @@ rm -rf ~/.exo
 ```
 
 Remove `~/.exo/bin` from your path.
-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20210608160410-67692ebc98de
 	github.com/BurntSushi/toml v0.3.1
-	github.com/alessio/shellescape v1.4.1 // indirect
+	github.com/alessio/shellescape v1.4.1
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59
 	github.com/containerd/containerd v1.5.4 // indirect
 	github.com/dgraph-io/badger/v3 v3.2103.1
@@ -33,7 +33,7 @@ require (
 	github.com/zclconf/go-cty v1.8.0
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069
 	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	mvdan.cc/sh/v3 v3.3.1

--- a/internal/util/osutil/fs.go
+++ b/internal/util/osutil/fs.go
@@ -2,6 +2,8 @@ package osutil
 
 import (
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 func Exists(filePath string) (bool, error) {
@@ -25,4 +27,9 @@ func IsSymlink(filePath string) (bool, error) {
 	}
 
 	return fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink, nil
+}
+
+func IsWritable(filePath string) (bool, error) {
+	err := unix.Access(filePath, unix.W_OK)
+	return err == nil, err
 }

--- a/internal/util/which/which.go
+++ b/internal/util/which/which.go
@@ -43,6 +43,7 @@ func (q Query) Run() (string, error) {
 	return "", fmt.Errorf("%q not found", q.Program)
 }
 
+// Uses the ambiant working directory and PATH variable.
 func Which(program string) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Partially implements #111. Partial because this is only _static_ completions. A more.. ahem... _complete_ implementation would also provide dynamic completion of component names and the like.

I looked around a fair bit to see if somebody had already done this, especially since Cobra commander supports the generation step, but seems like no one has done it in a reusable/extractable/robust way. Luckily, it wasn't too hard.