### PR TITLE
Add Dark Mode

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="/deref-rounded-icon.png" />
     <link rel="stylesheet" href="/globals.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta content="light dark" name="color-scheme" />
     <title>exo</title>
   </head>
 

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -90,9 +90,77 @@
     0 0.4px 0 0.8px #0000001a inset;
 }
 
-/* @media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
   :root {
-    --color: #fff;
-    --primary-bg-color: #061a29;
+    --primary-color: #aaaaaa;
+    --strong-color: #ffffff;
+    --grey-1-color: #eeeeee;
+    --grey-2-color: #dddddd;
+    --grey-3-color: #cccccc;
+    --grey-4-color: #bbbbbb;
+    --grey-5-color: #aaaaaa;
+    --grey-6-color: #999999;
+    --grey-7-color: #888888;
+    --grey-8-color: #777777;
+    --grey-9-color: #666666;
+    --grey-a-color: #555555;
+    --grey-b-color: #444444;
+    --grey-c-color: #333333;
+    --grey-d-color: #222222;
+    --grey-e-color: #111111;
+    --grey-e7-color: #0c0c0c;
+    --grey-f9-color: #070707;
+    --layout-bg-color: #333333;
+    --secondary-bg-color: #050505;
+    --primary-bg-color: #000000;
+    /* Contextual color */
+    --error-color: #ee0000;
+    --link-color: #007bd4;
+    --online-green-color: #00c220;
+    /* Nav */
+    --nav-bg-color: #0c0c0c;
+    --nav-button-active-bg-color: #151515;
+    --nav-button-active-hover-bg-color: #1c1c1c;
+    --dev-mode-bg-color: #0066ee;
+    --dev-mode-color: #ffffff;
+    /* Code */
+    --code-bg-color: #aaaaaa11;
+    --code-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 9px -4px #00000033,
+      0 0.4px 0 0.8px #0000001a;
+    /* Process details */
+    --sparkline-stroke: #ee0000;
+    --sparkline-fill: #ee000044;
+    /* Spinners */
+    --spinner-grey: #777777ff;
+    --spinner-grey-light: #77777733;
+    /* Checkbox */
+    --checkbox-color: #999999ff;
+    --checkbox-bg-color: #99999900;
+    --checkbox-border-color: #99999977;
+    --checkbox-hover-color: #777777;
+    --checkbox-hover-bg-color: #99999922;
+    --checkbox-focus-bg-color: #99999944;
+    --checkbox-active-hover-bg-color: #19baff22;
+    --checkbox-active-focus-bg-color: #19baff44;
+    --checkbox-active-color: #19baff;
+    --checkbox-active-border-color: #19baff77;
+    /* Buttons */
+    --icon-button-bg-color: #eeeeee00;
+    --icon-button-hover-bg-color: #eeeeee18;
+    --icon-button-focus-bg-color: #eeeeee33;
+    --button-background: linear-gradient(#222222, #111111);
+    --button-hover-background: linear-gradient(#333333, #222222);
+    --button-active-background: linear-gradient(#191919, #090909);
+    --button-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 8px -3px #00000026,
+      0 0.4px 0 0.8px #00000040;
+    --button-hover-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 8px -4px #00000033,
+      0 0.4px 0 0.8px #00000059;
+    --button-active-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 6px -3px #00000026,
+      0 0.4px 0 0.8px #00000073;
+    /* Shadows */
+    --heavy-3d-box-shadow: 0 0.33px 0 1px #ffffff26, 0 8px 12px -6px #0000004d,
+      0 0.5px 0 1px #00000033;
+    --text-input-shadow: 0 0.33px 0 1px #ffffff26,
+      0 6px 9px -4px #0000001a inset, 0 0.4px 0 0.8px #0000001a inset;
   }
-} */
+}

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -110,7 +110,7 @@
     --grey-e-color: #111111;
     --grey-e7-color: #0c0c0c;
     --grey-f9-color: #070707;
-    --layout-bg-color: #333333;
+    --layout-bg-color: #222222;
     --secondary-bg-color: #050505;
     --primary-bg-color: #000000;
     /* Contextual color */

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -149,7 +149,7 @@
     --icon-button-hover-bg-color: #eeeeee18;
     --icon-button-focus-bg-color: #eeeeee33;
     --button-background: linear-gradient(#222222, #111111);
-    --button-hover-background: linear-gradient(#333333, #222222);
+    --button-hover-background: linear-gradient(#333333, #151515);
     --button-active-background: linear-gradient(#191919, #090909);
     --button-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 8px -3px #00000026,
       0 0.4px 0 0.8px #00000040;

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -111,15 +111,15 @@
     --grey-e7-color: #0c0c0c;
     --grey-f9-color: #070707;
     --layout-bg-color: #222222;
-    --secondary-bg-color: #050505;
+    --secondary-bg-color: #0a0a0a;
     --primary-bg-color: #000000;
     /* Contextual color */
     --error-color: #ee0000;
     --link-color: #007bd4;
     --online-green-color: #00c220;
     /* Nav */
-    --nav-bg-color: #0c0c0c;
-    --nav-button-active-bg-color: #151515;
+    --nav-bg-color: #050505;
+    --nav-button-active-bg-color: #111111;
     --nav-button-active-hover-bg-color: #1c1c1c;
     --dev-mode-bg-color: #0066ee;
     --dev-mode-color: #ffffff;
@@ -148,19 +148,19 @@
     --icon-button-bg-color: #eeeeee00;
     --icon-button-hover-bg-color: #eeeeee18;
     --icon-button-focus-bg-color: #eeeeee33;
-    --button-background: linear-gradient(#222222, #111111);
-    --button-hover-background: linear-gradient(#333333, #151515);
-    --button-active-background: linear-gradient(#191919, #090909);
-    --button-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 8px -3px #00000026,
+    --button-background: linear-gradient(#141414, #040404);
+    --button-hover-background: linear-gradient(#242424, #111111);
+    --button-active-background: linear-gradient(#111111, #000000);
+    --button-shadow: 0 -0.33px 0 1px #ffffff26, 0 4px 8px -3px #00000026,
       0 0.4px 0 0.8px #00000040;
-    --button-hover-shadow: 0 0.33px 0 1px #ffffff26, 0 6px 8px -4px #00000033,
+    --button-hover-shadow: 0 -0.33px 0 1px #ffffff26, 0 6px 8px -4px #00000033,
       0 0.4px 0 0.8px #00000059;
-    --button-active-shadow: 0 0.33px 0 1px #ffffff26, 0 4px 6px -3px #00000026,
+    --button-active-shadow: 0 -0.33px 0 1px #ffffff26, 0 4px 6px -3px #00000026,
       0 0.4px 0 0.8px #00000073;
     /* Shadows */
-    --heavy-3d-box-shadow: 0 0.33px 0 1px #ffffff26, 0 8px 12px -6px #0000004d,
+    --heavy-3d-box-shadow: 0 -0.33px 0 1px #ffffff26, 0 8px 12px -6px #0000004d,
       0 0.5px 0 1px #00000033;
-    --text-input-shadow: 0 0.33px 0 1px #ffffff26,
+    --text-input-shadow: 0 -0.33px 0 1px #ffffff26,
       0 6px 9px -4px #0000001a inset, 0 0.4px 0 0.8px #0000001a inset;
   }
 }

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -26,14 +26,14 @@
     }
   };
 
-  const mqList = window.matchMedia('(prefers-color-scheme: dark)');
-
-  const handleThemeChange = (e: MediaQueryListEvent) => {
-    setTheme(e.matches);
-    console.log('test color listener');
-  };
-
   onMount(() => {
+    const mqList = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleThemeChange = (e: MediaQueryListEvent) => {
+      setTheme(e.matches);
+      console.log('test color listener');
+    };
+
     const editor = monaco.editor.create(container!, {
       value,
       language,

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -26,6 +26,13 @@
     }
   };
 
+  const mqList = window.matchMedia('(prefers-color-scheme: dark)');
+
+  const handleThemeChange = (e: MediaQueryListEvent) => {
+    setTheme(e.matches);
+    console.log('test color listener');
+  };
+
   onMount(() => {
     const editor = monaco.editor.create(container!, {
       value,
@@ -45,29 +52,15 @@
     });
 
     // Initialize dark mode if set
-    setTheme(
-      window.matchMedia &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches,
-    );
+    setTheme(mqList.matches);
 
     // Listen to system theme preference changes and set color theme
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener('change', (e) => {
-        setTheme(e.matches);
-      });
+    mqList.addEventListener('change', handleThemeChange);
 
     return () => {
+      mqList.removeEventListener('change', handleThemeChange);
       editor.dispose();
     };
-  });
-
-  onDestroy(() => {
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .removeEventListener('change', (e) => {
-        setTheme(e.matches);
-      });
   });
 </script>
 

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import * as monaco from 'monaco-editor';
   import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+  import { exo_dark, exo_light } from '../lib/monaco-theme';
 
-  import { onDestroy, onMount } from 'svelte';
-  import Panel from './Panel.svelte';
+  import { onMount } from 'svelte';
 
   export let id: string | undefined;
   export let value: string = '';
@@ -18,15 +18,18 @@
 
   let container: HTMLDivElement | null = null;
 
-  const setTheme = (dark: boolean) => {
-    if (dark) {
-      monaco.editor.setTheme('vs-dark');
-    } else {
-      monaco.editor.setTheme('vs-light');
-    }
-  };
-
   onMount(() => {
+    monaco.editor.defineTheme('exo-light', exo_light);
+    monaco.editor.defineTheme('exo-dark', exo_dark);
+
+    const setTheme = (dark: boolean) => {
+      if (dark) {
+        monaco.editor.setTheme('exo-dark');
+      } else {
+        monaco.editor.setTheme('exo-light');
+      }
+    };
+
     const mqList = window.matchMedia('(prefers-color-scheme: dark)');
 
     const handleThemeChange = (e: MediaQueryListEvent) => {

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -3,6 +3,7 @@
   import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 
   import { onMount } from 'svelte';
+  import Panel from './Panel.svelte';
 
   export let id: string | undefined;
   export let value: string = '';
@@ -16,6 +17,14 @@
   };
 
   let container: HTMLDivElement | null = null;
+
+  const setTheme = (dark: boolean) => {
+    if (dark) {
+      monaco.editor.setTheme('vs-dark');
+    } else {
+      monaco.editor.setTheme('vs-light');
+    }
+  };
 
   onMount(() => {
     const editor = monaco.editor.create(container!, {
@@ -34,6 +43,19 @@
     editor.onDidChangeModelContent((event) => {
       value = editor.getValue();
     });
+
+    // Initialize dark mode if set
+    setTheme(
+      window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches,
+    );
+
+    // Listen to system theme preference changes and set color theme
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', (e) => {
+        setTheme(e.matches);
+      });
 
     return () => {
       editor.dispose();

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -2,7 +2,7 @@
   import * as monaco from 'monaco-editor';
   import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import Panel from './Panel.svelte';
 
   export let id: string | undefined;
@@ -60,6 +60,14 @@
     return () => {
       editor.dispose();
     };
+  });
+
+  onDestroy(() => {
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .removeEventListener('change', (e) => {
+        setTheme(e.matches);
+      });
   });
 </script>
 

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -19,6 +19,7 @@
   let container: HTMLDivElement | null = null;
 
   onMount(() => {
+    // Define custom exo color themes for Monaco.
     monaco.editor.defineTheme('exo-light', exo_light);
     monaco.editor.defineTheme('exo-dark', exo_dark);
 
@@ -30,6 +31,8 @@
       }
     };
 
+    // Initialize the Media Query List and handler objects for
+    // finding and applying system color theme changes.
     const mqList = window.matchMedia('(prefers-color-scheme: dark)');
 
     const handleThemeChange = (e: MediaQueryListEvent) => {
@@ -54,10 +57,10 @@
       value = editor.getValue();
     });
 
-    // Initialize dark mode if set
+    // Initialize dark mode if set.
     setTheme(mqList.matches);
 
-    // Listen to system theme preference changes and set color theme
+    // Listen to system theme preference changes and set color theme.
     mqList.addEventListener('change', handleThemeChange);
 
     return () => {

--- a/gui/src/components/Textarea.svelte
+++ b/gui/src/components/Textarea.svelte
@@ -12,6 +12,8 @@
     border: none;
     border-radius: 4px;
     padding: 12px 18px;
+    background: var(--primary-bg-color);
+    color: var(--strong-color);
     box-shadow: var(--text-input-shadow);
     width: 100%;
     height: 120px;

--- a/gui/src/components/Textbox.svelte
+++ b/gui/src/components/Textbox.svelte
@@ -13,6 +13,8 @@
     border: none;
     border-radius: 4px;
     padding: 12px 18px;
+    background: var(--primary-bg-color);
+    color: var(--strong-color);
     box-shadow: var(--text-input-shadow);
     width: var(--input-width);
   }

--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -96,6 +96,18 @@
     color: var(--log-hover-color);
   }
 
+  @media (prefers-color-scheme: dark) {
+    .name {
+      background: var(--dark-log-bg-color);
+      color: var(--dark-log-color);
+    }
+
+    tr:hover .name {
+      background: var(--dark-log-bg-hover-color);
+      color: var(--dark-log-hover-color);
+    }
+  }
+
   .time {
     color: var(--grey-9-color);
     cursor: zoom-in;

--- a/gui/src/components/processes/ProcessRunControls.svelte
+++ b/gui/src/components/processes/ProcessRunControls.svelte
@@ -14,7 +14,7 @@
   {#if statusPending.has(id)}
     <Spinner />
   {:else if running}
-    <div class="running" />
+    <div class="running unhover-only" />
     <div class="control hover-only">
       <IconButton tooltip="Stop process" on:click={() => setProcRun(id, false)}>
         <StopSVG />

--- a/gui/src/lib/color.ts
+++ b/gui/src/lib/color.ts
@@ -13,13 +13,21 @@ export const textHoverColor = (deg: number) => `hsl(${deg}, 95%, 20%)`;
 export const bgColor = (deg: number) => `hsl(${deg}, 65%, 92%)`;
 export const bgHoverColor = (deg: number) => `hsl(${deg}, 65%, 87%)`;
 
+export const darkTextColor = (deg: number) => `hsl(${deg}, 75%, 75%)`;
+export const darkTextHoverColor = (deg: number) => `hsl(${deg}, 75%, 90%)`;
+export const darkBgColor = (deg: number) => `hsl(${deg}, 80%, 6%)`;
+export const darkBgHoverColor = (deg: number) => `hsl(${deg}, 80%, 12%)`;
+
 // This computes a HTML style attribute string for colored logs.
 export const logStyleFromHash = (s: string) => {
   const d = hashDegree(s);
   // Combine styles into one string.
-  return `--log-color:${textColor(d)};--log-bg-color:${bgColor(
-    d,
-  )};--log-hover-color:${textHoverColor(d)};--log-bg-hover-color:${bgHoverColor(
-    d,
-  )}`;
+  return `--log-color:${textColor(d)};
+  --log-bg-color:${bgColor(d)};
+  --log-hover-color:${textHoverColor(d)};
+  --log-bg-hover-color:${bgHoverColor(d)};
+  --dark-log-color:${darkTextColor(d)};
+  --dark-log-bg-color:${darkBgColor(d)};
+  --dark-log-hover-color:${darkTextHoverColor(d)};
+  --dark-log-bg-hover-color:${darkBgHoverColor(d)}`;
 };

--- a/gui/src/lib/monaco-theme.ts
+++ b/gui/src/lib/monaco-theme.ts
@@ -3,13 +3,13 @@ import type * as monaco from 'monaco-editor';
 // This file contains custom Monaco Editor color themes,
 // based on the "vs" and "vs-dark" built-in themes,
 // but adapted in both cases to better suit the exo GUI:
-//   * Color palette
-//   * Contrast levels
-//   * Editor background panel
+//   * Color palette.
+//   * Contrast levels.
+//   * Editor background panel.
 //
 // There may be a need for a third theme if the code
 // editors / log streams / etc don't have a #000000
-// background in the non-Black "Dark" theme
+// background in the non-Black "Dark" theme.
 
 export const exo_light: monaco.editor.IStandaloneThemeData = {
   base: 'vs',

--- a/gui/src/lib/monaco-theme.ts
+++ b/gui/src/lib/monaco-theme.ts
@@ -1,5 +1,16 @@
 import type * as monaco from 'monaco-editor';
 
+// This file contains custom Monaco Editor color themes,
+// based on the "vs" and "vs-dark" built-in themes,
+// but adapted in both cases to better suit the exo GUI:
+//   * Color palette
+//   * Contrast levels
+//   * Editor background panel
+//
+// There may be a need for a third theme if the code
+// editors / log streams / etc don't have a #000000
+// background in the non-Black "Dark" theme
+
 export const exo_light: monaco.editor.IStandaloneThemeData = {
   base: 'vs',
   inherit: false,

--- a/gui/src/lib/monaco-theme.ts
+++ b/gui/src/lib/monaco-theme.ts
@@ -1,0 +1,128 @@
+import type * as monaco from 'monaco-editor';
+
+export const exo_light: monaco.editor.IStandaloneThemeData = {
+  base: 'vs',
+  inherit: false,
+  rules: [
+    { token: '', foreground: '000000', background: 'ffffff' },
+    { token: 'invalid', foreground: 'cd3131' },
+    { token: 'emphasis', fontStyle: 'italic' },
+    { token: 'strong', fontStyle: 'bold' },
+
+    { token: 'variable', foreground: '001188' },
+    { token: 'variable.predefined', foreground: '4864AA' },
+    { token: 'constant', foreground: 'dd0000' },
+    { token: 'comment', foreground: '008000' },
+    { token: 'number', foreground: '098658' },
+    { token: 'number.hex', foreground: '3030c0' },
+    { token: 'regexp', foreground: '800000' },
+    { token: 'annotation', foreground: '808080' },
+    { token: 'type', foreground: '008080' },
+
+    { token: 'delimiter', foreground: '000000' },
+    { token: 'delimiter.html', foreground: '383838' },
+    { token: 'delimiter.xml', foreground: '0000FF' },
+
+    { token: 'tag', foreground: '800000' },
+    { token: 'tag.id.pug', foreground: '4F76AC' },
+    { token: 'tag.class.pug', foreground: '4F76AC' },
+    { token: 'meta.scss', foreground: '800000' },
+    { token: 'metatag', foreground: 'e00000' },
+    { token: 'metatag.content.html', foreground: 'FF0000' },
+    { token: 'metatag.html', foreground: '808080' },
+    { token: 'metatag.xml', foreground: '808080' },
+    { token: 'metatag.php', fontStyle: 'bold' },
+
+    { token: 'key', foreground: '863B00' },
+    { token: 'string.key.json', foreground: 'A31515' },
+    { token: 'string.value.json', foreground: '0451A5' },
+
+    { token: 'attribute.name', foreground: 'FF0000' },
+    { token: 'attribute.value', foreground: '0451A5' },
+    { token: 'attribute.value.number', foreground: '098658' },
+    { token: 'attribute.value.unit', foreground: '098658' },
+    { token: 'attribute.value.html', foreground: '0000FF' },
+    { token: 'attribute.value.xml', foreground: '0000FF' },
+
+    { token: 'string', foreground: 'A31515' },
+    { token: 'string.html', foreground: '0000FF' },
+    { token: 'string.sql', foreground: 'FF0000' },
+    { token: 'string.yaml', foreground: '0451A5' },
+
+    { token: 'keyword', foreground: '0000FF' },
+    { token: 'keyword.json', foreground: '0451A5' },
+    { token: 'keyword.flow', foreground: 'AF00DB' },
+    { token: 'keyword.flow.scss', foreground: '0000FF' },
+
+    { token: 'operator.scss', foreground: '666666' },
+    { token: 'operator.sql', foreground: '778899' },
+    { token: 'operator.swift', foreground: '666666' },
+    { token: 'predefined.sql', foreground: 'C700C7' },
+  ],
+  colors: {
+    'editor.background': '#ffffff',
+  },
+};
+
+export const exo_dark: monaco.editor.IStandaloneThemeData = {
+  base: 'vs-dark',
+  inherit: false,
+  rules: [
+    { token: '', foreground: 'D4D4D4', background: '000000' },
+    { token: 'invalid', foreground: 'f44747' },
+    { token: 'emphasis', fontStyle: 'italic' },
+    { token: 'strong', fontStyle: 'bold' },
+
+    { token: 'variable', foreground: '74B0DF' },
+    { token: 'variable.predefined', foreground: '4864AA' },
+    { token: 'variable.parameter', foreground: '9CDCFE' },
+    { token: 'constant', foreground: '569CD6' },
+    { token: 'comment', foreground: '608B4E' },
+    { token: 'number', foreground: 'B5CEA8' },
+    { token: 'number.hex', foreground: '5BB498' },
+    { token: 'regexp', foreground: 'B46695' },
+    { token: 'annotation', foreground: 'cc6666' },
+    { token: 'type', foreground: '3DC9B0' },
+
+    { token: 'delimiter', foreground: 'DCDCDC' },
+    { token: 'delimiter.html', foreground: '808080' },
+    { token: 'delimiter.xml', foreground: '808080' },
+
+    { token: 'tag', foreground: '569CD6' },
+    { token: 'tag.id.pug', foreground: '4F76AC' },
+    { token: 'tag.class.pug', foreground: '4F76AC' },
+    { token: 'meta.scss', foreground: 'A79873' },
+    { token: 'meta.tag', foreground: 'CE9178' },
+    { token: 'metatag', foreground: 'DD6A6F' },
+    { token: 'metatag.content.html', foreground: '9CDCFE' },
+    { token: 'metatag.html', foreground: '569CD6' },
+    { token: 'metatag.xml', foreground: '569CD6' },
+    { token: 'metatag.php', fontStyle: 'bold' },
+
+    { token: 'key', foreground: '9CDCFE' },
+    { token: 'string.key.json', foreground: '9CDCFE' },
+    { token: 'string.value.json', foreground: 'CE9178' },
+
+    { token: 'attribute.name', foreground: '9CDCFE' },
+    { token: 'attribute.value', foreground: 'CE9178' },
+    { token: 'attribute.value.number.css', foreground: 'B5CEA8' },
+    { token: 'attribute.value.unit.css', foreground: 'B5CEA8' },
+    { token: 'attribute.value.hex.css', foreground: 'D4D4D4' },
+
+    { token: 'string', foreground: 'CE9178' },
+    { token: 'string.sql', foreground: 'FF0000' },
+
+    { token: 'keyword', foreground: '569CD6' },
+    { token: 'keyword.flow', foreground: 'C586C0' },
+    { token: 'keyword.json', foreground: 'CE9178' },
+    { token: 'keyword.flow.scss', foreground: '569CD6' },
+
+    { token: 'operator.scss', foreground: '909090' },
+    { token: 'operator.sql', foreground: '778899' },
+    { token: 'operator.swift', foreground: '909090' },
+    { token: 'predefined.sql', foreground: 'FF00FF' },
+  ],
+  colors: {
+    'editor.background': '#000000',
+  },
+};


### PR DESCRIPTION
# Ta-da!

![image](https://user-images.githubusercontent.com/51100181/129988459-bad9d9ba-9ea5-4842-9850-3c0d2d632b59.png)


## Gallery

![image](https://user-images.githubusercontent.com/51100181/129988488-649bcfad-d6c8-4fe6-88ad-d72d58bee7e1.png)

![image](https://user-images.githubusercontent.com/51100181/129988503-3aa1c547-ad8a-403c-8350-07b0f8f8f5dc.png)

![image](https://user-images.githubusercontent.com/51100181/129988515-afb4ddd1-6f13-423b-92d8-3827b90395b8.png)

![image](https://user-images.githubusercontent.com/51100181/129988549-ab004d9a-b52e-4210-a5b0-1e18f3670d36.png)

![image](https://user-images.githubusercontent.com/51100181/129988596-ab3765e1-9fe8-479d-bc31-905576ee677c.png)


## Todo

- [x] Inputs and code editors need to be dark.
- [ ] Fix any small issues. (e.g. button text and background both dark in some cases?)
- [x] Fix Event Listener memory leak with `onDestroy`

**Later:**
- [ ] User preferences page to manually select color theme (**auto, light, dark, black**) and synchronize across browsers/sessions with a stored preference file.
- [ ] Improve contrast for dark greys.
- [ ] Replace Event Listener JS theme switch for `TextEditor` with a singleton store to access theme within TS
- [ ] **Black** and **Dark** themes to give users an option between pure-black `#000000` OLED-friendly dark theme and the more common dark-grey backgrounds dark theme.