### PR TITLE
Visual fixes 19/08/21

### DIFF
--- a/gui/public/globals.css
+++ b/gui/public/globals.css
@@ -19,6 +19,7 @@ input,
 textarea {
   font-family: var(--font-sans);
   font-size: inherit;
+  color: inherit;
 }
 
 input,

--- a/gui/public/theme.css
+++ b/gui/public/theme.css
@@ -92,7 +92,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --primary-color: #aaaaaa;
+    --primary-color: #ffffff;
     --strong-color: #ffffff;
     --grey-1-color: #eeeeee;
     --grey-2-color: #dddddd;

--- a/gui/src/components/WorkspaceList.svelte
+++ b/gui/src/components/WorkspaceList.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import * as router from 'svelte-spa-router';
+  import type { WorkspaceDescription } from '../lib/api';
+
+  export let workspaces: WorkspaceDescription[];
+</script>
+
+{#each workspaces as workspace}
+  <button
+    on:click={() => {
+      router.push(`/workspaces/${encodeURIComponent(workspace.id)}`);
+    }}
+  >
+    <b>{workspace.id}</b>
+    <span title={workspace.root}>{workspace.root}</span>
+  </button>
+{/each}
+
+<style>
+  button {
+    background: var(--button-background);
+    box-shadow: var(--button-shadow);
+    border: none;
+    border-radius: 4px;
+    padding: 16px 24px;
+    position: relative;
+    display: grid;
+    grid-template-columns: max-content 2fr;
+    align-items: center;
+    gap: 12px;
+    margin-top: 12px;
+  }
+
+  button > b {
+    max-width: 6em;
+  }
+
+  button > * {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  button:hover {
+    background: var(--button-hover-background);
+    box-shadow: var(--button-hover-shadow);
+  }
+
+  button:active {
+    background: var(--button-active-background);
+    box-shadow: var(--button-active-shadow);
+  }
+</style>

--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -77,7 +77,7 @@
     padding: 0 0.3em;
     vertical-align: text-top;
     color: var(--grey-3-color);
-    white-space: pre-line;
+    white-space: pre-wrap;
   }
 
   tr:hover td {

--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -77,7 +77,7 @@
     padding: 0 0.3em;
     vertical-align: text-top;
     color: var(--grey-3-color);
-    white-space: pre-wrap;
+    white-space: pre-line;
   }
 
   tr:hover td {

--- a/gui/src/pages/Home.svelte
+++ b/gui/src/pages/Home.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import Code from '../components/Code.svelte';
-  import Layout from '../components/Layout.svelte';
   import Panel from '../components/Panel.svelte';
-  import * as router from 'svelte-spa-router';
+  import Layout from '../components/Layout.svelte';
+  import WorkspaceList from '../components/WorkspaceList.svelte';
   import { api } from '../lib/api';
 
   const workspaces = api.kernel
@@ -14,27 +14,15 @@
 
 <Layout>
   <Panel title="Workspaces">
-    <p>
+    <div>
       Use <Code>exo gui</Code> in your terminal to launch into the current directory's
       workspace.
-    </p>
+    </div>
     <div>
       {#await workspaces}
         loading workspaces...
       {:then workspaces}
-        <ul>
-          {#each workspaces as workspace}
-            <li
-              class="a"
-              on:click={() => {
-                router.push(`/workspaces/${encodeURIComponent(workspace.id)}`);
-              }}
-            >
-              <b>{workspace.id}</b>
-              <span title={workspace.root}>{workspace.root}</span>
-            </li>
-          {/each}
-        </ul>
+        <WorkspaceList {workspaces} />
       {:catch error}
         <p style="color: red">{error.message}</p>
       {/await}
@@ -43,51 +31,7 @@
 </Layout>
 
 <style>
-  p {
-    margin: 0;
+  div {
     margin-bottom: 24px;
-  }
-
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 16px;
-    /* Auto-responsive */
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  }
-
-  li {
-    background: var(--button-background);
-    box-shadow: var(--button-shadow);
-    border: none;
-    border-radius: 4px;
-    padding: 16px 24px;
-    position: relative;
-    display: grid;
-    grid-template-columns: max-content 2fr;
-    align-items: center;
-    gap: 12px;
-  }
-
-  li > b {
-    max-width: 6em;
-  }
-
-  li > * {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
-  li:hover {
-    background: var(--button-hover-background);
-    box-shadow: var(--button-hover-shadow);
-  }
-
-  li:active {
-    background: var(--button-active-background);
-    box-shadow: var(--button-active-shadow);
   }
 </style>


### PR DESCRIPTION
This:

- Extracts `WorkspaceList` to its own component and uses a one-column layout to show as much of the directory path as possible
    - This should help a bit with #231 , but does not actually add custom names and renaming, it just shows more of the workspace directory in the list
- Improves dark mode text contrast
- Fixes a bug in FireFox where buttons and inputs didn't inherit inherit the correct text color automatically

![image](https://user-images.githubusercontent.com/51100181/130083891-50d81ac7-869e-43ad-9e3a-ca469ee7e755.png)
