### PR TITLE
Dependency graph

### DIFF
--- a/internal/deps/graph.go
+++ b/internal/deps/graph.go
@@ -1,0 +1,201 @@
+package deps
+
+import (
+	"errors"
+)
+
+// Semantically, this is Map<Node, Set<Node>>.
+type depmap map[interface{}]map[interface{}]struct{}
+
+type Graph struct {
+	// Maintain dependency relationships in both directions.
+	// `dependencies` tracks child -> parent, and `dependents` tracks parents -> children.
+	dependencies, dependents depmap
+}
+
+func New() *Graph {
+	return &Graph{
+		dependencies: make(depmap),
+		dependents:   make(depmap),
+	}
+}
+
+func (g *Graph) DependOn(node, dep interface{}) error {
+	if node == dep {
+		return errors.New("self-referential dependencies not allowed")
+	}
+	if g.DependsOn(dep, node) {
+		return errors.New("circular dependencies not allowed")
+	}
+
+	updateSet(g.dependencies, node, func(nodes map[interface{}]struct{}) {
+		nodes[dep] = struct{}{}
+	})
+	updateSet(g.dependents, dep, func(nodes map[interface{}]struct{}) {
+		nodes[node] = struct{}{}
+	})
+
+	return nil
+}
+
+func (g *Graph) DependsOn(node, dep interface{}) bool {
+	tds := g.transitiveDependencies(node)
+	_, ok := tds[dep]
+	return ok
+}
+
+func (g *Graph) HasDependent(node, dep interface{}) bool {
+	tds := g.transitiveDependents(node)
+	_, ok := tds[dep]
+	return ok
+}
+
+func (g *Graph) Nodes() []interface{} {
+	approxSize := len(g.dependencies) + len(g.dependents)/2
+	allNodes := make(map[interface{}]struct{}, approxSize)
+	var nodeCount int
+	for node := range g.dependencies {
+		nodeCount++
+		allNodes[node] = struct{}{}
+	}
+	for node := range g.dependents {
+		if _, exists := allNodes[node]; !exists {
+			nodeCount++
+			allNodes[node] = struct{}{}
+		}
+	}
+
+	distinctNodes := make([]interface{}, nodeCount)
+	for node := range allNodes {
+		distinctNodes[nodeCount-1] = node
+		nodeCount--
+	}
+
+	return distinctNodes
+}
+
+func (g *Graph) Leaves() []interface{} {
+	out := make([]interface{}, 0)
+	for node := range g.dependents {
+		if _, ok := g.dependencies[node]; !ok {
+			out = append(out, node)
+		}
+	}
+	return out
+}
+
+// TopoSorted returns a slice of all of the graph nodes in topological sort order. That is,
+// if `B` depends on `A`, then `A` is guaranteed to come before `B` in the sorted output.
+// The graph is guaranteed to be cycle-free because cycles are detected while building the
+// graph. This implements Kahn's algorithm for topological sorting.
+func (g *Graph) TopoSorted() []interface{} {
+	out := []interface{}{}
+
+	// Copy dependency information to be mutated below.
+	// dependencies: child -> parents
+	dependencies := make(depmap)
+	for k, v := range g.dependencies {
+		dependencies[k] = v
+	}
+	// dependents: parent -> children
+	dependents := make(depmap)
+	for k, v := range g.dependents {
+		dependents[k] = v
+	}
+
+	// Keep track of the set of nodes whose dependencies have already been met.
+	dependenciesMet := make(map[interface{}]struct{})
+	markDependenciesMet := func(node interface{}) {
+		// Mark node as not depending on anything already in `out`.
+		dependenciesMet[node] = struct{}{}
+		// Remove the record of everything that depended on `node`.
+		dependsOnNode := dependents[node]
+		for dependingNode := range dependsOnNode {
+			delete(dependencies[dependingNode], node)
+			if len(dependencies[dependingNode]) == 0 {
+				delete(dependencies, dependingNode)
+			}
+		}
+	}
+	for _, leafNode := range g.Leaves() {
+		markDependenciesMet(leafNode)
+	}
+
+	for len(dependenciesMet) > 0 {
+		elem := setPop(dependenciesMet)
+		out = append(out, elem)
+		for dependentNode := range dependents[elem] {
+			if _, hasDependents := dependencies[dependentNode]; !hasDependents {
+				markDependenciesMet(dependentNode)
+			}
+		}
+	}
+
+	return out
+}
+
+func (g *Graph) transitiveDependencies(node interface{}) map[interface{}]struct{} {
+	return g.buildTransitive(node, g.immediateDependencies)
+}
+
+func (g *Graph) immediateDependencies(node interface{}) map[interface{}]struct{} {
+	if deps, ok := g.dependencies[node]; ok {
+		return deps
+	}
+	return nil
+}
+
+func (g *Graph) transitiveDependents(node interface{}) map[interface{}]struct{} {
+	return g.buildTransitive(node, g.immediateDependents)
+}
+
+func (g *Graph) immediateDependents(node interface{}) map[interface{}]struct{} {
+	if deps, ok := g.dependents[node]; ok {
+		return deps
+	}
+	return nil
+}
+
+// buildTransitive starts at `root` and continues calling `nextFn` to keep discovering more nodes until
+// the graph cannot produce any more. It returns the set of all discovered nodes.
+func (g *Graph) buildTransitive(root interface{}, nextFn func(interface{}) map[interface{}]struct{}) map[interface{}]struct{} {
+	out := make(map[interface{}]struct{})
+	searchNext := []interface{}{root}
+	for len(searchNext) > 0 {
+		// List of new nodes from this layer of the dependency graph. This is
+		// assigned to `searchNext` at the end of the outer "discovery" loop.
+		discovered := []interface{}{}
+		for _, node := range searchNext {
+			// For each node to discover, find the next nodes.
+			for nextNode := range nextFn(node) {
+				// If we have not seen the node before, add it to the output as well
+				// as the list of nodes to traverse in the next iteration.
+				if _, ok := out[nextNode]; !ok {
+					out[nextNode] = struct{}{}
+					discovered = append(discovered, nextNode)
+				}
+			}
+		}
+		searchNext = discovered
+	}
+	return out
+}
+
+type updateFn = func(nodes map[interface{}]struct{})
+
+func updateSet(ds depmap, node interface{}, fn updateFn) {
+	nodeSet, ok := ds[node]
+	if !ok {
+		nodeSet = make(map[interface{}]struct{})
+		ds[node] = nodeSet
+	}
+	fn(nodeSet)
+}
+
+func setPop(set map[interface{}]struct{}) interface{} {
+	for elem := range set {
+		defer delete(set, elem)
+		return elem
+	}
+	return nil
+}

--- a/internal/deps/graph.go
+++ b/internal/deps/graph.go
@@ -121,7 +121,7 @@ func (g *Graph) Leaves() []interface{} {
 	return out
 }
 
-// TopoSorted returns a slice of all of the graph nodes in topological sort order. That is,
+// TopoSortedLayers returns a slice of all of the graph nodes in topological sort order. That is,
 // if `B` depends on `A`, then `A` is guaranteed to come before `B` in the sorted output.
 // The graph is guaranteed to be cycle-free because cycles are detected while building the
 // graph. Additionally, the output is grouped into "layers", which are guaranteed to not have
@@ -267,13 +267,4 @@ func updateSet(ds depmap, node interface{}, fn updateFn) {
 		ds[node] = nodeSet
 	}
 	fn(nodeSet)
-}
-
-func shift(xs *[]interface{}) interface{} {
-	if len(*xs) == 0 {
-		panic("must not call when empty")
-	}
-	x := (*xs)[0]
-	*xs = (*xs)[1:]
-	return x
 }

--- a/internal/deps/graph_test.go
+++ b/internal/deps/graph_test.go
@@ -1,0 +1,109 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/deref/exo/internal/deps"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImmediateDependencies(t *testing.T) {
+	g := deps.New()
+
+	assert.NoError(t, g.DependOn("x", "y"))
+
+	assert.True(t, g.DependsOn("x", "y"))
+	assert.True(t, g.HasDependent("y", "x"))
+	assert.False(t, g.DependsOn("y", "x"))
+	assert.False(t, g.HasDependent("x", "y"))
+
+	// No self-dependencies.
+	assert.Error(t, g.DependOn("z", "z"))
+	// No bidirectional dependencies.
+	assert.Error(t, g.DependOn("y", "x"))
+}
+
+func TestTransitiveDependencies(t *testing.T) {
+	g := deps.New()
+
+	assert.NoError(t, g.DependOn("x", "y"))
+	assert.NoError(t, g.DependOn("y", "z"))
+
+	assert.True(t, g.DependsOn("x", "z"))
+	assert.True(t, g.HasDependent("z", "x"))
+	assert.False(t, g.DependsOn("z", "x"))
+	assert.False(t, g.HasDependent("x", ""))
+
+	// No circular dependencies.
+	assert.Error(t, g.DependOn("z", "x"))
+}
+
+func TestLeaves(t *testing.T) {
+	g := deps.New()
+	g.DependOn("cake", "eggs")
+	g.DependOn("cake", "flour")
+	g.DependOn("eggs", "chickens")
+	g.DependOn("flour", "grain")
+	g.DependOn("chickens", "feed")
+	g.DependOn("chickens", "grain")
+	g.DependOn("grain", "soil")
+
+	leaves := g.Leaves()
+	assert.ElementsMatch(t, leaves, []interface{}{"feed", "soil"})
+}
+
+func TestTopologicalSort(t *testing.T) {
+	g := deps.New()
+	g.DependOn("cake", "eggs")
+	g.DependOn("cake", "flour")
+	g.DependOn("eggs", "chickens")
+	g.DependOn("flour", "grain")
+	g.DependOn("chickens", "grain")
+	g.DependOn("grain", "soil")
+
+	sorted := g.TopoSorted()
+	pairs := []struct {
+		before interface{}
+		after  interface{}
+	}{
+		{
+			before: "soil",
+			after:  "grain",
+		},
+		{
+			before: "grain",
+			after:  "chickens",
+		},
+		{
+			before: "grain",
+			after:  "flour",
+		},
+		{
+			before: "chickens",
+			after:  "eggs",
+		},
+		{
+			before: "flour",
+			after:  "cake",
+		},
+		{
+			before: "eggs",
+			after:  "cake",
+		},
+	}
+	comesBefore := func(before, after interface{}) bool {
+		iBefore := -1
+		iAfter := -1
+		for i, elem := range sorted {
+			if elem == before {
+				iBefore = i
+			} else if elem == after {
+				iAfter = i
+			}
+		}
+		return iBefore < iAfter
+	}
+	for _, pair := range pairs {
+		assert.True(t, comesBefore(pair.before, pair.after))
+	}
+}


### PR DESCRIPTION
This work is a prerequisite to #171 and #237. It adds a dependency graph that can represent an arbitrary DAG (cycles are prevented when the graph is being built) and can return its nodes sorted topologically. Additionally, it keeps track of groups of nodes at the same "level" of the graph (i.e. nodes that have no interdependencies) and can return these groups in topological sort order as well. I plan to use this to build an execution plan for starting and stopping components such that everything that can start in parallel does start in parallel.