### PR TITLE
Support for workspace .env file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gofrs/flock v0.8.1
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/influxdata/go-syslog/v3 v3.0.0
+	github.com/joho/godotenv v1.3.0
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-isatty v0.0.13
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/influxdata/go-syslog/v3 v3.0.0/go.mod h1:tulsOp+CecTAYC27u9miMgq21GqX
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/providers/core/components/invalid/component.go
+++ b/internal/providers/core/components/invalid/component.go
@@ -5,7 +5,7 @@ type Invalid struct {
 }
 
 func (invalid *Invalid) InitResource() error {
-	return nil
+	return invalid.Err
 }
 
 func (invalid *Invalid) MarshalState() (state string, err error) {

--- a/internal/providers/docker/components/container/lifecycle.go
+++ b/internal/providers/docker/components/container/lifecycle.go
@@ -56,6 +56,18 @@ func (c *Container) create(ctx context.Context) error {
 		labels[k] = v
 	}
 
+	envMap := map[string]string{}
+	for k, v := range c.WorkspaceEnvironment {
+		envMap[k] = v
+	}
+	for k, v := range c.Spec.Environment.WithoutNils() {
+		envMap[k] = v
+	}
+	envSlice := []string{}
+	for k, v := range envMap {
+		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	containerCfg := &container.Config{
 		Hostname:     c.Spec.Hostname,
 		Domainname:   c.Spec.Domainname,
@@ -64,7 +76,7 @@ func (c *Container) create(ctx context.Context) error {
 		Tty:          c.Spec.TTY,
 		OpenStdin:    c.Spec.StdinOpen,
 		// StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
-		Env:         c.Spec.Environment.Slice(),
+		Env:         envSlice,
 		Cmd:         strslice.StrSlice(c.Spec.Command),
 		Healthcheck: healthCfg,
 		// ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).

--- a/internal/providers/docker/components/network/lifecycle.go
+++ b/internal/providers/docker/components/network/lifecycle.go
@@ -26,7 +26,7 @@ func (n *Network) Initialize(ctx context.Context, input *core.InitializeInput) (
 			return nil, fmt.Errorf("listing networks: %w", err)
 		}
 		if len(nets) == 0 {
-			return nil, fmt.Errorf("network %q not found", n.Name)
+			return nil, fmt.Errorf("network %q was not found", n.Name)
 		}
 
 		n.NetworkID = nets[0].ID


### PR DESCRIPTION
This adds support for a workspace having a `.env` file. At the moment there is no support for per-component environments.