### PR TITLE
Add better, instant, styled tooltips to navbar items

### DIFF
--- a/gui/src/components/CodeBlock.svelte
+++ b/gui/src/components/CodeBlock.svelte
@@ -4,7 +4,8 @@
   pre {
     background: var(--code-bg-color);
     box-shadow: var(--heavy-3d-box-shadow);
-    font-size: 16px;
+    font-size: 15px;
+    font-weight: 400;
     border-radius: 0.33em;
     padding: 0.667em 1em;
   }

--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -74,7 +74,7 @@
     position: relative;
     width: 48px;
     height: 100vh;
-    z-index: 3;
+    z-index: 4;
     display: grid;
     grid-template-rows: auto 1fr max-content;
     grid-auto-flow: column;
@@ -84,7 +84,6 @@
 
   .navbar-wrapper {
     width: 48px;
-    overflow-y: auto;
     border-top: 1px solid var(--layout-bg-color);
     border-bottom: 1px solid var(--layout-bg-color);
   }
@@ -96,16 +95,6 @@
   .content-wrapper {
     position: relative;
     z-index: 2;
-    overflow: hidden;
-  }
-
-  footer {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    font-size: 11px;
-    width: 100%;
-    color: var(--grey-5-color);
     overflow: hidden;
   }
 </style>

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -52,7 +52,9 @@
       folding: false,
       lineDecorationsWidth: 0,
       lineNumbersMinChars: 0,
-      fontSize: 16,
+      fontSize: 15,
+      fontWeight: '400',
+      fontFamily: 'Fira Code, mono',
       minimap: {
         enabled: false,
       },

--- a/gui/src/components/Tooltip.svelte
+++ b/gui/src/components/Tooltip.svelte
@@ -1,0 +1,16 @@
+<div><slot /></div>
+
+<style>
+  div {
+    display: inline-block;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--strong-color);
+    background: var(--primary-bg-color);
+    box-shadow: var(--dropdown-shadow);
+    height: 22px;
+    padding: 3px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
+</style>

--- a/gui/src/components/VersionInfo.svelte
+++ b/gui/src/components/VersionInfo.svelte
@@ -86,7 +86,7 @@
     margin-top: 8px;
   }
 
-  .dropdown-wrapper:not(:hover) .dropdown {
+  .dropdown-wrapper:not(:hover):not(:focus-within) .dropdown {
     display: none;
   }
 

--- a/gui/src/components/nav/NavbarButton.svelte
+++ b/gui/src/components/nav/NavbarButton.svelte
@@ -3,11 +3,39 @@
   export let active: string | undefined = undefined;
 </script>
 
-<button on:click class:active={title && active === title} {title}>
-  <slot />
-</button>
+<div>
+  <button on:click class:active={title && active === title}>
+    <slot />
+  </button>
+  {#if title}
+    <span>{title}</span>
+  {/if}
+</div>
 
 <style>
+  div {
+    position: relative;
+  }
+
+  div:not(:hover):not(:focus-within) span {
+    display: none;
+  }
+
+  span {
+    display: inline-block;
+    position: absolute;
+    left: calc(100% - 4px);
+    top: calc(50% - 11px);
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--strong-color);
+    background: var(--primary-bg-color);
+    box-shadow: var(--dropdown-shadow);
+    height: 22px;
+    padding: 3px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
   button {
     position: relative;
     border: none;

--- a/gui/src/components/nav/NavbarButton.svelte
+++ b/gui/src/components/nav/NavbarButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Tooltip from '../Tooltip.svelte';
+
   export let title: string | undefined = undefined;
   export let active: string | undefined = undefined;
 </script>
@@ -8,7 +10,7 @@
     <slot />
   </button>
   {#if title}
-    <span>{title}</span>
+    <div class="tooltip"><Tooltip>{title}</Tooltip></div>
   {/if}
 </div>
 
@@ -17,24 +19,14 @@
     position: relative;
   }
 
-  div:not(:hover):not(:focus-within) span {
+  div:not(:hover):not(:focus-within) .tooltip {
     display: none;
   }
 
-  span {
-    display: inline-block;
+  .tooltip {
     position: absolute;
     left: calc(100% - 4px);
     top: calc(50% - 11px);
-    font-size: 13px;
-    font-weight: 400;
-    color: var(--strong-color);
-    background: var(--primary-bg-color);
-    box-shadow: var(--dropdown-shadow);
-    height: 22px;
-    padding: 3px 6px;
-    border-radius: 4px;
-    white-space: nowrap;
   }
   button {
     position: relative;

--- a/gui/src/components/processes/ProcessRunControls.svelte
+++ b/gui/src/components/processes/ProcessRunControls.svelte
@@ -66,6 +66,6 @@
 
   .control {
     position: absolute;
-    z-index: 4;
+    z-index: 3;
   }
 </style>

--- a/gui/src/pages/NewProcess.svelte
+++ b/gui/src/pages/NewProcess.svelte
@@ -18,6 +18,7 @@
 
   const workspaceId = params.workspace;
   const workspace = api.workspace(workspaceId);
+  const workspaceRoute = `/workspaces/${encodeURIComponent(workspaceId)}`;
   const workspaceNewComponentRoute = `/workspaces/${encodeURIComponent(
     workspaceId,
   )}/new-component`;


### PR DESCRIPTION
Adds a custom tooltip which is perfectly bound to `hover` or `focus-within` for navbar buttons - this differs from the system's `title` attribute tooltips which for some browser implementations can take some time to reveal upon hover and sometimes don't reveal at all.

![image](https://user-images.githubusercontent.com/51100181/130653620-f14cfddc-d588-4eef-8ba2-0670ef5b7a9c.png)
![image](https://user-images.githubusercontent.com/51100181/130653644-c4124e71-46a3-46ec-8eed-ff7ef903d935.png)
