### PR TITLE
New Process fixes

### DIFF
--- a/gui/src/components/CodeBlock.svelte
+++ b/gui/src/components/CodeBlock.svelte
@@ -4,7 +4,8 @@
   pre {
     background: var(--code-bg-color);
     box-shadow: var(--heavy-3d-box-shadow);
-    font-size: 16px;
+    font-size: 15px;
+    font-weight: 400;
     border-radius: 0.33em;
     padding: 0.667em 1em;
   }

--- a/gui/src/components/TextEditor.svelte
+++ b/gui/src/components/TextEditor.svelte
@@ -52,7 +52,9 @@
       folding: false,
       lineDecorationsWidth: 0,
       lineNumbersMinChars: 0,
-      fontSize: 16,
+      fontSize: 15,
+      fontWeight: '400',
+      fontFamily: 'Fira Code, mono',
       minimap: {
         enabled: false,
       },

--- a/gui/src/pages/NewProcess.svelte
+++ b/gui/src/pages/NewProcess.svelte
@@ -18,6 +18,7 @@
 
   const workspaceId = params.workspace;
   const workspace = api.workspace(workspaceId);
+  const workspaceRoute = `/workspaces/${encodeURIComponent(workspaceId)}`;
   const workspaceNewComponentRoute = `/workspaces/${encodeURIComponent(
     workspaceId,
   )}/new-component`;


### PR DESCRIPTION
Some fixes:

- Re-adds a route in the new process page missing from #241 
- Uses `Fira Code`, our standard code font, instead of `Consolas` or whatever other default Monaco would otherwise use.
- Fine tunes code font typography