### PR TITLE
Add commands to get/set/clear/edit component state

### DIFF
--- a/cmd/exo/state.go
+++ b/cmd/exo/state.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/deref/exo/internal/core/api"
+	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/exo/internal/util/which"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(stateCmd)
+	stateCmd.AddCommand(stateGetCmd)
+	stateCmd.AddCommand(stateSetCmd)
+	stateCmd.AddCommand(stateClearCmd)
+	stateCmd.AddCommand(stateEditCmd)
+
+	stateCmd.AddCommand(helpSubcmd)
+}
+
+var stateCmd = &cobra.Command{
+	Use:    "state",
+	Short:  "View and update the state store.",
+	Long:   `Contains subcommands for getting, setting, and clearing state on a per-component basis.`,
+	Hidden: true,
+	Args:   cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+var stateGetCmd = &cobra.Command{
+	Use:    "get <component>",
+	Short:  "Print component state",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		componentRef := args[0]
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+
+		workspace := requireWorkspace(ctx, cl)
+		output, err := workspace.GetComponentState(ctx, &api.GetComponentStateInput{Ref: componentRef})
+		if err != nil {
+			return err
+		}
+
+		return jsonutil.PrettyPrintJSONString(os.Stdout, output.State)
+	},
+}
+
+var stateSetCmd = &cobra.Command{
+	Use:    "set <component>",
+	Short:  "Set component state",
+	Long:   "Set component state to the JSON received on stdin.",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		componentRef := args[0]
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+
+		var newState map[string]interface{}
+		if err := json.NewDecoder(os.Stdin).Decode(&newState); err != nil {
+			return fmt.Errorf("reading state from stdin: %v", err)
+		}
+
+		workspace := requireWorkspace(ctx, cl)
+		_, err := workspace.SetComponentState(ctx, &api.SetComponentStateInput{
+			Ref:   componentRef,
+			State: jsonutil.MustMarshalString(newState),
+		})
+		return err
+	},
+}
+
+var stateClearCmd = &cobra.Command{
+	Use:    "clear <component>",
+	Short:  "Clear component state",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		componentRef := args[0]
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+
+		workspace := requireWorkspace(ctx, cl)
+		_, err := workspace.SetComponentState(ctx, &api.SetComponentStateInput{
+			Ref:   componentRef,
+			State: "{}",
+		})
+		return err
+	},
+}
+
+var stateEditCmd = &cobra.Command{
+	Use:    "edit <component>",
+	Short:  "Edit component state",
+	Long:   "Edit component state using your preferred editor.",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		componentRef := args[0]
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+
+		workspace := requireWorkspace(ctx, cl)
+		output, err := workspace.GetComponentState(ctx, &api.GetComponentStateInput{Ref: componentRef})
+		if err != nil {
+			return err
+		}
+
+		tmpfile, err := ioutil.TempFile("", "state.*.json")
+		if err != nil {
+			return fmt.Errorf("creating temporary file: %w", err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		if err := jsonutil.PrettyPrintJSONString(tmpfile, output.State); err != nil {
+			return fmt.Errorf("writing to temporary file: %w", err)
+		}
+		if err := tmpfile.Close(); err != nil {
+			return fmt.Errorf("closing temporary file: %w", err)
+		}
+
+		// TODO: Read from EDITOR, or guess from common editors.
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting working directory: %w", err)
+			}
+			pathVar, _ := os.LookupEnv("PATH")
+
+			for _, candidateEditor := range []string{
+				"code",
+				"vim",
+				"nano",
+				"vi",
+				"emacs",
+				"ee",
+			} {
+				found, err := which.Query{
+					WorkingDirectory: wd,
+					PathVariable:     pathVar,
+					Program:          candidateEditor,
+				}.Run()
+				if err != nil && !strings.Contains(err.Error(), "not found") {
+					return fmt.Errorf("looking up candidate editor %q: %w", candidateEditor, err)
+				}
+				if found != "" {
+					editor = found
+					break
+				}
+			}
+
+			if editor == "" {
+				return errors.New("No editor available")
+			}
+		}
+
+		edit := exec.Command(editor, tmpfile.Name())
+		edit.Stdin = os.Stdin
+		edit.Stdout = os.Stdout
+		edit.Stderr = os.Stderr
+		if err := edit.Run(); err != nil {
+			return fmt.Errorf("editing state file: %w", err)
+		}
+
+		newState, err := os.ReadFile(tmpfile.Name())
+		if err != nil {
+			return fmt.Errorf("reading updated state: %w", err)
+		}
+
+		_, err = workspace.SetComponentState(ctx, &api.SetComponentStateInput{
+			Ref:   componentRef,
+			State: string(newState),
+		})
+		return err
+	},
+}

--- a/cmd/exo/state.go
+++ b/cmd/exo/state.go
@@ -141,6 +141,8 @@ var stateEditCmd = &cobra.Command{
 		if editor == "" {
 
 			for _, candidateEditor := range []string{
+				"sensible-editor",
+				"editor",
 				"code",
 				"vim",
 				"nano",

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -90,6 +90,8 @@ type Workspace interface {
 	DisposeComponents(context.Context, *DisposeComponentsInput) (*DisposeComponentsOutput, error)
 	// Asynchronously disposes components, then removes them from the manifest.
 	DeleteComponents(context.Context, *DeleteComponentsInput) (*DeleteComponentsOutput, error)
+	GetComponentState(context.Context, *GetComponentStateInput) (*GetComponentStateOutput, error)
+	SetComponentState(context.Context, *SetComponentStateInput) (*SetComponentStateOutput, error)
 	DescribeLogs(context.Context, *DescribeLogsInput) (*DescribeLogsOutput, error)
 	// Returns pages of log events for some set of logs. If `cursor` is specified, standard pagination behavior is used. Otherwise the cursor is assumed to represent the current tail of the log.
 	GetEvents(context.Context, *GetEventsInput) (*GetEventsOutput, error)
@@ -204,6 +206,22 @@ type DeleteComponentsInput struct {
 
 type DeleteComponentsOutput struct {
 	JobID string `json:"jobId"`
+}
+
+type GetComponentStateInput struct {
+	Ref string `json:"ref"`
+}
+
+type GetComponentStateOutput struct {
+	State string `json:"state"`
+}
+
+type SetComponentStateInput struct {
+	Ref   string `json:"ref"`
+	State string `json:"state"`
+}
+
+type SetComponentStateOutput struct {
 }
 
 type DescribeLogsInput struct {
@@ -353,6 +371,12 @@ func BuildWorkspaceMux(b *josh.MuxBuilder, factory func(req *http.Request) Works
 	})
 	b.AddMethod("delete-components", func(req *http.Request) interface{} {
 		return factory(req).DeleteComponents
+	})
+	b.AddMethod("get-component-state", func(req *http.Request) interface{} {
+		return factory(req).GetComponentState
+	})
+	b.AddMethod("set-component-state", func(req *http.Request) interface{} {
+		return factory(req).SetComponentState
 	})
 	b.AddMethod("describe-logs", func(req *http.Request) interface{} {
 		return factory(req).DescribeLogs

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -131,6 +131,17 @@ interface "workspace" {
     output "job-id" "string" {}
   }
 
+  method "get-component-state" {
+    input "ref" "string" {}
+
+    output "state" "string" {}
+  }
+
+  method "set-component-state" {
+    input "ref" "string" {}
+    input "state" "string" {}
+  }
+
   method "describe-logs" {
     input "refs" "[]string" {}
 

--- a/internal/core/client/workspace.go
+++ b/internal/core/client/workspace.go
@@ -135,6 +135,16 @@ func (c *Workspace) DeleteComponents(ctx context.Context, input *api.DeleteCompo
 	return
 }
 
+func (c *Workspace) GetComponentState(ctx context.Context, input *api.GetComponentStateInput) (output *api.GetComponentStateOutput, err error) {
+	err = c.client.Invoke(ctx, "get-component-state", input, &output)
+	return
+}
+
+func (c *Workspace) SetComponentState(ctx context.Context, input *api.SetComponentStateInput) (output *api.SetComponentStateOutput, err error) {
+	err = c.client.Invoke(ctx, "set-component-state", input, &output)
+	return
+}
+
 func (c *Workspace) DescribeLogs(ctx context.Context, input *api.DescribeLogsInput) (output *api.DescribeLogsOutput, err error) {
 	err = c.client.Invoke(ctx, "describe-logs", input, &output)
 	return

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -480,6 +480,48 @@ func (ws *Workspace) deleteComponent(ctx context.Context, lifecycle api.Lifecycl
 	return nil
 }
 
+func (ws *Workspace) GetComponentState(ctx context.Context, input *api.GetComponentStateInput) (*api.GetComponentStateOutput, error) {
+	query := makeComponentQuery(withRefs(input.Ref))
+	describe, err := query.describeComponentsInput(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+
+	describeOutput, err := ws.DescribeComponents(ctx, describe)
+	if err != nil {
+		return nil, fmt.Errorf("describing components: %w", err)
+	}
+
+	if len(describeOutput.Components) == 0 {
+		return nil, fmt.Errorf("component not found: %q", input.Ref)
+	}
+
+	return &api.GetComponentStateOutput{
+		State: describeOutput.Components[0].State,
+	}, nil
+}
+
+func (ws *Workspace) SetComponentState(ctx context.Context, input *api.SetComponentStateInput) (*api.SetComponentStateOutput, error) {
+	id, err := ws.resolveRef(ctx, input.Ref)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that state is legal JSON.
+	if !jsonutil.IsValid(input.State) {
+		return nil, fmt.Errorf("state is not valid JSON")
+	}
+
+	if _, err = ws.Store.PatchComponent(ctx, &state.PatchComponentInput{
+		ID:    id,
+		State: input.State,
+	}); err != nil {
+		return nil, fmt.Errorf("updating state: %w", err)
+	}
+
+	return &api.SetComponentStateOutput{}, nil
+}
+
 func (ws *Workspace) DescribeLogs(ctx context.Context, input *api.DescribeLogsInput) (*api.DescribeLogsOutput, error) {
 	describe, err := allProcessQuery().describeComponentsInput(ctx, ws)
 	if err != nil {

--- a/internal/util/jsonutil/jsonutil.go
+++ b/internal/util/jsonutil/jsonutil.go
@@ -63,3 +63,20 @@ func MarshalFile(filePath string, v interface{}) error {
 	bs = append(bs, '\n')
 	return ioutil.WriteFile(filePath, bs, 0600)
 }
+
+func PrettyPrintJSONString(w io.Writer, jsonStr string) error {
+	var val interface{}
+	if err := UnmarshalString(jsonStr, &val); err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(val)
+}
+
+func IsValid(jsonStr string) bool {
+	var val interface{}
+	err := UnmarshalString(jsonStr, &val)
+	return err == nil
+}

--- a/internal/util/which/which.go
+++ b/internal/util/which/which.go
@@ -42,3 +42,17 @@ func (q Query) Run() (string, error) {
 	}
 	return "", fmt.Errorf("%q not found", q.Program)
 }
+
+func Which(program string) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	pathVar, _ := os.LookupEnv("PATH")
+
+	return Query{
+		WorkingDirectory: wd,
+		PathVariable:     pathVar,
+		Program:          program,
+	}.Run()
+}


### PR DESCRIPTION
Adds the following commands:

- `exo state  get COMPONENT` - dumps component state to stdout
- `exo state set COMPONENT` - reads JSON from stdin and saves it as new component state
- `exo state clear COMPONENT` - sets component state to be an empty object
- `exo state edit COMPONENT` - opens component state in system editor and saves changes

Fixes #271 