### PR TITLE
Use the same build context as docker build command

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,7 @@ github.com/Microsoft/hcsshim v0.8.10/go.mod h1:g5uw8EV2mAlzqe94tfNBNdr89fnbD/n3H
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
+github.com/Microsoft/hcsshim v0.8.18 h1:cYnKADiM1869gvBpos3YCteeT6sZLB48lB5dmMMs8Tg=
 github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim/test v0.0.0-20200826032352-301c83a30e7c/go.mod h1:30A5igQ91GEmhYJF8TaRP79pMBOYynRsyOByfVV0dU4=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
@@ -243,6 +244,7 @@ github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
 github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
 github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
+github.com/containerd/cgroups v1.0.1 h1:iJnMvco9XGvKUvNQkv88bE4uJXxRQH18efbKo9w5vHQ=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -275,6 +277,7 @@ github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
+github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
@@ -840,10 +843,12 @@ github.com/moby/moby v20.10.8+incompatible h1:Bq+xfiSjbCmVwhvm0vWDdQt0s/p99LF1Dr
 github.com/moby/moby v20.10.8+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/mount v0.1.0/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
 github.com/moby/sys/mount v0.1.1/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
+github.com/moby/sys/mount v0.2.0 h1:WhCW5B355jtxndN5ovugJlMFJawbUODuW8fSnEH6SSM=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
 github.com/moby/sys/mountinfo v0.1.0/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/sys/mountinfo v0.4.1 h1:1O+1cHA1aujwEwwVMa2Xm2l+gIpUHyd3+D+d7LZh1kM=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
@@ -921,6 +926,7 @@ github.com/opencontainers/runc v1.0.0-rc10/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2r
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc92/go.mod h1:X1zlU4p7wOlX4+WRCz+hvlRv8phdL7UqbYD+vQwNMmE=
+github.com/opencontainers/runc v1.0.0-rc93 h1:x2UMpOOVf3kQ8arv/EsDGwim8PTNqzL1/EYDr/+scOM=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=

--- a/internal/providers/docker/components/container/build.go
+++ b/internal/providers/docker/components/container/build.go
@@ -54,6 +54,7 @@ func (c *Container) buildImage(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("getting build context: %w", err)
 	}
+	defer buildContext.Close()
 
 	opts := types.ImageBuildOptions{
 		//Tags           []string

--- a/internal/providers/docker/components/container/build.go
+++ b/internal/providers/docker/components/container/build.go
@@ -217,15 +217,15 @@ func getArchive(contextDir, relDockerfile string) (io.ReadCloser, error) {
 	// removed. The daemon will remove them for us, if needed, after it
 	// parses the Dockerfile.
 	var includes = []string{"."}
-	keepThem1, err := fileutils.Matches(".dockerignore", excludes)
+	isIgnoringDockerIgnore, err := fileutils.Matches(".dockerignore", excludes)
 	if err != nil {
 		return nil, fmt.Errorf("matching .dockerignore: %w", err)
 	}
-	keepThem2, err := fileutils.Matches(relDockerfile, excludes)
+	isIgnoringDockerfile, err := fileutils.Matches(relDockerfile, excludes)
 	if err != nil {
 		return nil, fmt.Errorf("matching Dockerfile: %w", err)
 	}
-	if keepThem1 || keepThem2 {
+	if isIgnoringDockerIgnore || isIgnoringDockerfile {
 		includes = append(includes, ".dockerignore", relDockerfile)
 	}
 

--- a/internal/providers/docker/components/container/build.go
+++ b/internal/providers/docker/components/container/build.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"archive/tar"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -11,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/deref/exo/internal/core/api"
 	"github.com/deref/exo/internal/task"
@@ -19,8 +17,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/moby/builder/dockerignore"
+	"github.com/moby/moby/pkg/archive"
 	"github.com/moby/moby/pkg/fileutils"
-	"golang.org/x/sync/errgroup"
 )
 
 func (c *Container) Build(ctx context.Context, input *api.BuildInput) (*api.BuildOutput, error) {
@@ -37,10 +35,6 @@ func (c *Container) canBuild() bool {
 }
 
 func (c *Container) buildImage(ctx context.Context) error {
-	buildContext, buildContextWriter := io.Pipe()
-	defer buildContextWriter.Close()
-	var eg errgroup.Group
-
 	buildTask := task.CurrentTask(ctx)
 	if buildTask == nil {
 		panic("No build task")
@@ -48,128 +42,127 @@ func (c *Container) buildImage(ctx context.Context) error {
 
 	spec := c.Spec
 
-	eg.Go(func() error {
-		contextPath := filepath.Join(c.WorkspaceRoot, spec.Build.Context)
-		if !pathutil.HasFilePathPrefix(contextPath, c.WorkspaceRoot) {
-			return errors.New("docker container build context path must be in exo workspace root")
-		}
-		if err := tarBuildContext(buildContextWriter, contextPath); err != nil {
-			return fmt.Errorf("tarring build context: %w", err)
-		}
-		return nil
-	})
+	contextPath := filepath.Join(c.WorkspaceRoot, spec.Build.Context)
+	if !pathutil.HasFilePathPrefix(contextPath, c.WorkspaceRoot) {
+		return errors.New("docker container build context path must be in exo workspace root")
+	}
+	dockerfile := c.Spec.Build.Dockerfile
+	if dockerfile == "" {
+		dockerfile = "Dockerfile"
+	}
+	buildContext, err := getArchive(contextPath, dockerfile)
+	if err != nil {
+		return fmt.Errorf("getting build context: %w", err)
+	}
 
-	eg.Go(func() error {
-		opts := types.ImageBuildOptions{
-			//Tags           []string
-			//SuppressOutput bool
-			//RemoteContext  string
-			//NoCache        bool
-			//Remove         bool
-			//ForceRemove    bool
-			//PullParent     bool
-			Isolation: container.Isolation(spec.Build.Isolation),
-			//CPUSetCPUs     string
-			//CPUSetMems     string
-			//CPUShares      int64
-			//CPUQuota       int64
-			//CPUPeriod      int64
-			//Memory         int64
-			//MemorySwap     int64
-			//CgroupParent   string
-			//NetworkMode    string
-			ShmSize:    int64(spec.Build.ShmSize),
-			Dockerfile: spec.Build.Dockerfile,
-			//Ulimits        []*units.Ulimit
-			//// BuildArgs needs to be a *string instead of just a string so that
-			//// we can tell the difference between "" (empty string) and no value
-			//// at all (nil). See the parsing of buildArgs in
-			//// api/server/router/build/build_routes.go for even more info.
-			BuildArgs: spec.Build.Args,
-			//AuthConfigs map[string]AuthConfig
-			//Context     io.Reader
-			Labels: spec.Build.Labels.WithoutNils(),
-			//// squash the resulting image's layers to the parent
-			//// preserves the original image and creates a new one from the parent with all
-			//// the changes applied to a single layer
-			//Squash bool
-			// CacheFrom specifies images that are used for matching cache. Images
-			// specified here do not need to have a valid parent chain to match cache.
-			CacheFrom: spec.Build.CacheFrom,
-			//SecurityOpt []string
-			ExtraHosts: spec.Build.ExtraHosts,
-			Target:     spec.Build.Target,
-			//SessionID   string
-			//Platform    string
-			//// Version specifies the version of the unerlying builder to use
-			//Version BuilderVersion
-			//// BuildID is an optional identifier that can be passed together with the
-			//// build request. The same identifier can be used to gracefully cancel the
-			//// build with the cancel request.
-			//BuildID string
-			//// Outputs defines configurations for exporting build results. Only supported
-			//// in BuildKit mode
-			//Outputs []ImageBuildOutput
-		}
-		resp, err := c.Docker.ImageBuild(ctx, buildContext, opts)
-		if resp.Body != nil {
-			defer resp.Body.Close()
+	opts := types.ImageBuildOptions{
+		//Tags           []string
+		//SuppressOutput bool
+		//RemoteContext  string
+		//NoCache        bool
+		//Remove         bool
+		//ForceRemove    bool
+		//PullParent     bool
+		Isolation: container.Isolation(spec.Build.Isolation),
+		//CPUSetCPUs     string
+		//CPUSetMems     string
+		//CPUShares      int64
+		//CPUQuota       int64
+		//CPUPeriod      int64
+		//Memory         int64
+		//MemorySwap     int64
+		//CgroupParent   string
+		//NetworkMode    string
+		ShmSize:    int64(spec.Build.ShmSize),
+		Dockerfile: spec.Build.Dockerfile,
+		//Ulimits        []*units.Ulimit
+		//// BuildArgs needs to be a *string instead of just a string so that
+		//// we can tell the difference between "" (empty string) and no value
+		//// at all (nil). See the parsing of buildArgs in
+		//// api/server/router/build/build_routes.go for even more info.
+		BuildArgs: spec.Build.Args,
+		//AuthConfigs map[string]AuthConfig
+		//Context     io.Reader
+		Labels: spec.Build.Labels.WithoutNils(),
+		//// squash the resulting image's layers to the parent
+		//// preserves the original image and creates a new one from the parent with all
+		//// the changes applied to a single layer
+		//Squash bool
+		// CacheFrom specifies images that are used for matching cache. Images
+		// specified here do not need to have a valid parent chain to match cache.
+		CacheFrom: spec.Build.CacheFrom,
+		//SecurityOpt []string
+		ExtraHosts: spec.Build.ExtraHosts,
+		Target:     spec.Build.Target,
+		//SessionID   string
+		//Platform    string
+		//// Version specifies the version of the unerlying builder to use
+		//Version BuilderVersion
+		//// BuildID is an optional identifier that can be passed together with the
+		//// build request. The same identifier can be used to gracefully cancel the
+		//// build with the cancel request.
+		//BuildID string
+		//// Outputs defines configurations for exporting build results. Only supported
+		//// in BuildKit mode
+		//Outputs []ImageBuildOutput
+	}
+	resp, err := c.Docker.ImageBuild(ctx, buildContext, opts)
+	if resp.Body != nil {
+		defer resp.Body.Close()
 
-			subtasks := make(map[string]*task.Task)
+		subtasks := make(map[string]*task.Task)
 
-			scanner := bufio.NewScanner(resp.Body)
-			for scanner.Scan() {
-				var event buildEvent
-				if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
-					return fmt.Errorf("failed to unmarshal docker build log: %w", err)
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			var event buildEvent
+			if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+				return fmt.Errorf("failed to unmarshal docker build log: %w", err)
+			}
+
+			if event.ErrorDetail.Message != "" {
+				// TODO: Report error code too.
+				return fmt.Errorf("docker build error: " + event.ErrorDetail.Message)
+			}
+
+			if event.ID != "" {
+				var subtask *task.Task
+				if subtask == nil && event.Status == "Pulling fs layer" {
+					subtask = buildTask.StartChild("layer " + event.ID)
+					subtasks[event.ID] = subtask
+				} else {
+					subtask = subtasks[event.ID]
 				}
-
-				if event.ErrorDetail.Message != "" {
-					// TODO: Report error code too.
-					return fmt.Errorf("docker build error: " + event.ErrorDetail.Message)
-				}
-
-				if event.ID != "" {
-					var subtask *task.Task
-					if subtask == nil && event.Status == "Pulling fs layer" {
-						subtask = buildTask.StartChild("layer " + event.ID)
-						subtasks[event.ID] = subtask
-					} else {
-						subtask = subtasks[event.ID]
+				if subtask != nil {
+					if event.Status != "" {
+						subtask.ReportMessage(event.Status)
 					}
-					if subtask != nil {
-						if event.Status != "" {
-							subtask.ReportMessage(event.Status)
-						}
-						if event.Status == "Pull complete" {
-							_ = subtask.Finish()
-						}
-						if event.ProgressDetail.Total > 0 {
-							subtask.ReportProgress(event.ProgressDetail.Current, event.ProgressDetail.Total)
-						}
+					if event.Status == "Pull complete" {
+						_ = subtask.Finish()
 					}
-				}
-
-				if event.Stream != "" {
-					message := strings.TrimSpace(event.Stream)
-					buildTask.ReportMessage(message)
-				}
-
-				if strings.HasPrefix(event.Aux.ID, "sha256:") {
-					c.State.Image.ID = event.Aux.ID
+					if event.ProgressDetail.Total > 0 {
+						subtask.ReportProgress(event.ProgressDetail.Current, event.ProgressDetail.Total)
+					}
 				}
 			}
-		}
-		if err != nil {
-			return err
-		}
-		if c.State.Image.ID == "" {
-			return fmt.Errorf("did not build an image")
-		}
-		return nil
-	})
 
-	return eg.Wait()
+			if event.Stream != "" {
+				message := strings.TrimSpace(event.Stream)
+				buildTask.ReportMessage(message)
+			}
+
+			if strings.HasPrefix(event.Aux.ID, "sha256:") {
+				c.State.Image.ID = event.Aux.ID
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if c.State.Image.ID == "" {
+		return fmt.Errorf("did not build an image")
+	}
+	return nil
+
 }
 
 // See <github.com/docker/docker/pkg/jsonmessage>.
@@ -198,102 +191,47 @@ type buildEvent struct {
 	} `json:"aux"`
 }
 
-func tarBuildContext(w io.WriteCloser, root string) (err error) {
-	defer func() {
-		err2 := w.Close()
-		if err == nil {
-			err = err2
-		}
-	}()
+func getArchive(contextDir, relDockerfile string) (io.ReadCloser, error) {
+	var err error
 
-	ignore, err := createIgnoreMatcher(root)
-	if err != nil {
-		return fmt.Errorf("reading dockerignore file: %w", err)
-	}
+	// Convert dockerfile name to a platform-independent one.
+	relDockerfile = archive.CanonicalTarNameForPath(relDockerfile)
 
-	tw := tar.NewWriter(w)
-
-	filepath.Walk(root, func(file string, info os.FileInfo, err error) error {
-		// Skip ignored files.
-		name := info.Name()
-		ignored, err := ignore.Matches(name)
-		if err != nil {
-			// This is expected to be unreachable.
-			// SEE NOTE: [LAZY_PATTERN_MATCHER].
-			return fmt.Errorf("matching %q: %w", name, err)
-		}
-		if ignored {
-			return nil
-		}
-
-		// Generate and write file header.
-		header, err := tar.FileInfoHeader(info, file)
-		if err != nil {
-			return err
-		}
-		header.Name, err = filepath.Rel(root, filepath.ToSlash(file))
-		if err != nil {
-			return err
-		}
-		if err := tw.WriteHeader(header); err != nil {
-			return err
-		}
-
-		// If not a directory, write file content.
-		if !info.IsDir() {
-			data, err := os.OpenFile(file, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(tw, data); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-
-	if err := tw.Close(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func createIgnoreMatcher(buildContext string) (*fileutils.PatternMatcher, error) {
-	patterns := []string{}
-
-	// Read additional patterns from ignore file.
-	ignorePath := filepath.Join(buildContext, ".dockerignore")
-	file, err := os.Open(ignorePath)
-	if os.IsNotExist(err) {
-		err = nil
-	}
-	if err != nil {
+	f, err := os.Open(filepath.Join(contextDir, ".dockerignore"))
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-	if file != nil {
-		defer file.Close()
 
-		morePatterns, err := dockerignore.ReadAll(file)
+	var excludes []string
+	if err == nil {
+		excludes, err = dockerignore.ReadAll(f)
 		if err != nil {
 			return nil, err
 		}
-		patterns = append(patterns, morePatterns...)
 	}
 
-	// Build a pattern matcher.
-	matcher, err := fileutils.NewPatternMatcher(patterns)
+	// If .dockerignore mentions .dockerignore or the Dockerfile
+	// then make sure we send both files over to the daemon
+	// because Dockerfile is, obviously, needed no matter what, and
+	// .dockerignore is needed to know if either one needs to be
+	// removed. The daemon will remove them for us, if needed, after it
+	// parses the Dockerfile.
+	var includes = []string{"."}
+	keepThem1, err := fileutils.Matches(".dockerignore", excludes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("matching .dockerignore: %w", err)
 	}
-	// NOTE [LAZY_PATTERN_MATCHER]: PatternMatcher compiles patterns lazily. If
-	// compilation of an individual pattern fails, the returned error does not
-	// not report which. Since the Matches method always visits every pattern, we
-	// can invoke it here to force pattern compilation eagerly. This won't help
-	// identifying which pattern failed to compile, but it will at least prevent
-	// the error from being reported confusingly in the context of a particular
-	// match operation.
-	if _, err := matcher.Matches(""); err != nil {
-		return nil, err
+	keepThem2, err := fileutils.Matches(relDockerfile, excludes)
+	if err != nil {
+		return nil, fmt.Errorf("matching Dockerfile: %w", err)
 	}
-	return matcher, nil
+	if keepThem1 || keepThem2 {
+		includes = append(includes, ".dockerignore", relDockerfile)
+	}
+
+	return archive.TarWithOptions(contextDir, &archive.TarOptions{
+		Compression:     archive.Uncompressed,
+		ExcludePatterns: excludes,
+		IncludeFiles:    includes,
+	})
 }


### PR DESCRIPTION
This is an attempt to ensure that we always build the same image that `docker build` would have (assuming BuildKit is not being used).