### PR TITLE
Use actual links in Compose create form help

### DIFF
--- a/gui/src/components/CodeBlock.svelte
+++ b/gui/src/components/CodeBlock.svelte
@@ -1,4 +1,8 @@
-<pre><code><slot/></code></pre>
+<script lang="ts">
+  export let code: string | undefined = undefined;
+</script>
+
+<pre><code>{code}</code></pre>
 
 <style>
   pre {

--- a/gui/src/pages/NewDockerComponent.svelte
+++ b/gui/src/pages/NewDockerComponent.svelte
@@ -10,7 +10,6 @@
   import Button from '../components/Button.svelte';
   import Textbox from '../components/Textbox.svelte';
   import EditAs from '../components/form/EditAs.svelte';
-  import CodeBlock from '../components/CodeBlock.svelte';
   import ErrorLabel from '../components/ErrorLabel.svelte';
   import TextEditor from '../components/TextEditor.svelte';
   import DockerSVG from '../components/mono/DockerSVG.svelte';
@@ -46,7 +45,6 @@
 
   export let componentType: string;
   export let displayType: string;
-  export let specExample: string;
 </script>
 
 <Layout>
@@ -94,12 +92,12 @@
             <label for="spec">Spec:</label>
             <TextEditor id="spec" bind:value={spec} language="yaml" />
           </div>
-          <details>
-            <summary>Show/hide example</summary>
-            <CodeBlock>
-              {specExample}
-            </CodeBlock>
-          </details>
+          {#if $$slots.help}
+            <details>
+              <summary>Show/hide example</summary>
+              <slot name="help" />
+            </details>
+          {/if}
         {:else}
           <!-- GUI form edit mode -->
         {/if}

--- a/gui/src/pages/NewDockerComponent.svelte
+++ b/gui/src/pages/NewDockerComponent.svelte
@@ -92,12 +92,10 @@
             <label for="spec">Spec:</label>
             <TextEditor id="spec" bind:value={spec} language="yaml" />
           </div>
-          {#if $$slots.help}
-            <details>
-              <summary>Show/hide example</summary>
-              <slot name="help" />
-            </details>
-          {/if}
+          <details>
+            <summary>Show/hide example</summary>
+            <slot />
+          </details>
         {:else}
           <!-- GUI form edit mode -->
         {/if}

--- a/gui/src/pages/NewDockerContainer.svelte
+++ b/gui/src/pages/NewDockerContainer.svelte
@@ -1,19 +1,25 @@
 <script lang="ts">
+  import CodeBlock from '../components/CodeBlock.svelte';
   import NewDockerComponent from './NewDockerComponent.svelte';
   import type { Params } from './NewDockerComponent.svelte';
 
   export let params: Params;
 
-  const specExample = `# See https://github.com/compose-spec/compose-spec/blob/master/spec.md#services-top-level-element
-image: postgres:9.4
+  const specExample = `image: postgres:9.4
 environment:
     POSTGRES_USER: "postgres"
     POSTGRES_PASSWORD: "postgres"`;
+  const href =
+    'https://github.com/compose-spec/compose-spec/blob/master/spec.md#services-top-level-element';
 </script>
 
-<NewDockerComponent
-  {params}
-  componentType="container"
-  displayType="Container"
-  {specExample}
-/>
+<NewDockerComponent {params} componentType="container" displayType="Container">
+  <div slot="help">
+    <p>
+      See <a {href}>services volume reference</a>.
+    </p>
+    <CodeBlock>
+      {specExample}
+    </CodeBlock>
+  </div>
+</NewDockerComponent>

--- a/gui/src/pages/NewDockerContainer.svelte
+++ b/gui/src/pages/NewDockerContainer.svelte
@@ -5,7 +5,7 @@
 
   export let params: Params;
 
-  const specExample = `image: postgres:9.4
+  const code = `image: postgres:9.4
 environment:
     POSTGRES_USER: "postgres"
     POSTGRES_PASSWORD: "postgres"`;
@@ -17,7 +17,5 @@ environment:
   <p>
     See <a {href}>services volume reference</a>.
   </p>
-  <CodeBlock>
-    {specExample}
-  </CodeBlock>
+  <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerContainer.svelte
+++ b/gui/src/pages/NewDockerContainer.svelte
@@ -14,8 +14,6 @@ environment:
 </script>
 
 <NewDockerComponent {params} componentType="container" displayType="Container">
-  <p>
-    See <a {href}>services volume reference</a>.
-  </p>
+  <p>See <a {href}>services volume reference</a>.</p>
   <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerContainer.svelte
+++ b/gui/src/pages/NewDockerContainer.svelte
@@ -14,12 +14,10 @@ environment:
 </script>
 
 <NewDockerComponent {params} componentType="container" displayType="Container">
-  <div slot="help">
-    <p>
-      See <a {href}>services volume reference</a>.
-    </p>
-    <CodeBlock>
-      {specExample}
-    </CodeBlock>
-  </div>
+  <p>
+    See <a {href}>services volume reference</a>.
+  </p>
+  <CodeBlock>
+    {specExample}
+  </CodeBlock>
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerNetwork.svelte
+++ b/gui/src/pages/NewDockerNetwork.svelte
@@ -11,12 +11,10 @@
 </script>
 
 <NewDockerComponent {params} componentType="network" displayType="Network">
-  <div slot="help">
-    <p>
-      See <a {href}>compose network reference</a>.
-    </p>
-    <CodeBlock>
-      {specExample}
-    </CodeBlock>
-  </div>
+  <p>
+    See <a {href}>compose network reference</a>.
+  </p>
+  <CodeBlock>
+    {specExample}
+  </CodeBlock>
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerNetwork.svelte
+++ b/gui/src/pages/NewDockerNetwork.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
+  import CodeBlock from '../components/CodeBlock.svelte';
   import NewDockerComponent from './NewDockerComponent.svelte';
   import type { Params } from './NewDockerComponent.svelte';
 
   export let params: Params;
 
-  const specExample = `# See https://github.com/compose-spec/compose-spec/blob/master/spec.md#Networks-top-level-element
-name: mynetwork`;
+  const specExample = `name: mynetwork`;
+  const href =
+    'https://github.com/compose-spec/compose-spec/blob/master/spec.md#Networks-top-level-element';
 </script>
 
-<NewDockerComponent
-  {params}
-  componentType="network"
-  displayType="Network"
-  {specExample}
-/>
+<NewDockerComponent {params} componentType="network" displayType="Network">
+  <div slot="help">
+    <p>
+      See <a {href}>compose network reference</a>.
+    </p>
+    <CodeBlock>
+      {specExample}
+    </CodeBlock>
+  </div>
+</NewDockerComponent>

--- a/gui/src/pages/NewDockerNetwork.svelte
+++ b/gui/src/pages/NewDockerNetwork.svelte
@@ -5,7 +5,7 @@
 
   export let params: Params;
 
-  const specExample = `name: mynetwork`;
+  const code = `name: mynetwork`;
   const href =
     'https://github.com/compose-spec/compose-spec/blob/master/spec.md#Networks-top-level-element';
 </script>
@@ -14,7 +14,5 @@
   <p>
     See <a {href}>compose network reference</a>.
   </p>
-  <CodeBlock>
-    {specExample}
-  </CodeBlock>
+  <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerNetwork.svelte
+++ b/gui/src/pages/NewDockerNetwork.svelte
@@ -11,8 +11,6 @@
 </script>
 
 <NewDockerComponent {params} componentType="network" displayType="Network">
-  <p>
-    See <a {href}>compose network reference</a>.
-  </p>
+  <p>See <a {href}>compose network reference</a>.</p>
   <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerVolume.svelte
+++ b/gui/src/pages/NewDockerVolume.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
+  import CodeBlock from '../components/CodeBlock.svelte';
   import NewDockerComponent from './NewDockerComponent.svelte';
   import type { Params } from './NewDockerComponent.svelte';
 
   export let params: Params;
 
-  const specExample = `# An empty YAML is a valid volume.
-# See https://github.com/compose-spec/compose-spec/blob/master/spec.md#volumes-top-level-element`;
+  const specExample = `# An empty YAML is a valid volume.`;
+  const href =
+    'https://github.com/compose-spec/compose-spec/blob/master/spec.md#volumes-top-level-element';
 </script>
 
-<NewDockerComponent
-  {params}
-  componentType="volume"
-  displayType="Volume"
-  {specExample}
-/>
+<NewDockerComponent {params} componentType="volume" displayType="Volume">
+  <div slot="help">
+    <p>
+      See <a {href}>compose volume reference</a>.
+    </p>
+    <CodeBlock>
+      {specExample}
+    </CodeBlock>
+  </div>
+</NewDockerComponent>

--- a/gui/src/pages/NewDockerVolume.svelte
+++ b/gui/src/pages/NewDockerVolume.svelte
@@ -11,8 +11,6 @@
 </script>
 
 <NewDockerComponent {params} componentType="volume" displayType="Volume">
-  <p>
-    See <a {href}>compose volume reference</a>.
-  </p>
+  <p>See <a {href}>compose volume reference</a>.</p>
   <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerVolume.svelte
+++ b/gui/src/pages/NewDockerVolume.svelte
@@ -5,7 +5,7 @@
 
   export let params: Params;
 
-  const specExample = `# An empty YAML is a valid volume.`;
+  const code = `# An empty YAML is a valid volume.`;
   const href =
     'https://github.com/compose-spec/compose-spec/blob/master/spec.md#volumes-top-level-element';
 </script>
@@ -14,7 +14,5 @@
   <p>
     See <a {href}>compose volume reference</a>.
   </p>
-  <CodeBlock>
-    {specExample}
-  </CodeBlock>
+  <CodeBlock {code} />
 </NewDockerComponent>

--- a/gui/src/pages/NewDockerVolume.svelte
+++ b/gui/src/pages/NewDockerVolume.svelte
@@ -11,12 +11,10 @@
 </script>
 
 <NewDockerComponent {params} componentType="volume" displayType="Volume">
-  <div slot="help">
-    <p>
-      See <a {href}>compose volume reference</a>.
-    </p>
-    <CodeBlock>
-      {specExample}
-    </CodeBlock>
-  </div>
+  <p>
+    See <a {href}>compose volume reference</a>.
+  </p>
+  <CodeBlock>
+    {specExample}
+  </CodeBlock>
 </NewDockerComponent>

--- a/gui/src/pages/NewProcess.svelte
+++ b/gui/src/pages/NewProcess.svelte
@@ -147,9 +147,7 @@ my-app --port 4000
             </div>
             <details>
               <summary>Show/hide example</summary>
-              <CodeBlock>
-                {codeExample}
-              </CodeBlock>
+              <CodeBlock code={codeExample} />
             </details>
             <div class="buttons">
               <Button type="submit">Create Process</Button>


### PR DESCRIPTION
Takes the links out of the codeblocks and puts them into actual links in the show/hide help sections of the Container, Volume, and Network creation forms.

![image](https://user-images.githubusercontent.com/51100181/132734542-ccd5b542-36be-42e9-9360-a034dd965a93.png)
