### PR TITLE
upgrade "find-workspace" to "resolve-workspace"

### DIFF
--- a/cmd/exo/apply.go
+++ b/cmd/exo/apply.go
@@ -51,7 +51,7 @@ var applyCmd = &cobra.Command{
 
 		cl := newClient()
 		kernel := cl.Kernel()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		return apply(ctx, kernel, workspace, args)
 	},

--- a/cmd/exo/control.go
+++ b/cmd/exo/control.go
@@ -13,7 +13,7 @@ func controlComponents(args []string, f controlFunc) error {
 	checkOrEnsureServer()
 	cl := newClient()
 	kernel := cl.Kernel()
-	workspace := requireWorkspace(ctx, cl)
+	workspace := requireCurrentWorkspace(ctx, cl)
 
 	var jobID string
 	var err error

--- a/cmd/exo/dispose.go
+++ b/cmd/exo/dispose.go
@@ -19,7 +19,7 @@ var disposeCmd = &cobra.Command{
 		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.DisposeComponents(ctx, &api.DisposeComponentsInput{
 			Refs: args,
 		})

--- a/cmd/exo/env.go
+++ b/cmd/exo/env.go
@@ -22,7 +22,7 @@ var envCmd = &cobra.Command{
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.DescribeEnvironment(ctx, &api.DescribeEnvironmentInput{})
 		if err != nil {
 			return err

--- a/cmd/exo/gui.go
+++ b/cmd/exo/gui.go
@@ -28,11 +28,11 @@ If the current directory is part of a workspace, navigates to it.`,
 		cl := newClient()
 
 		cwd := cmdutil.MustGetwd()
-		output, err := cl.Kernel().FindWorkspace(ctx, &api.FindWorkspaceInput{
-			Path: cwd,
+		output, err := cl.Kernel().ResolveWorkspace(ctx, &api.ResolveWorkspaceInput{
+			Ref: cwd,
 		})
 		if err != nil {
-			return fmt.Errorf("finding workspace: %w", err)
+			return fmt.Errorf("resolving workspace: %w", err)
 		}
 
 		routes := newGUIRoutes()

--- a/cmd/exo/kill.go
+++ b/cmd/exo/kill.go
@@ -26,7 +26,7 @@ The default signal is SIGKILL.`,
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		// We could use controlComponents here, but that does an implicit `watchJob`
 		// which we don't want, since signal sending is so fast that we want to treat

--- a/cmd/exo/logs.go
+++ b/cmd/exo/logs.go
@@ -30,7 +30,7 @@ If refs are provided, filters for the logs of those processes.`,
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		stopOnError := false
 		return tailLogs(ctx, workspace, args, stopOnError)

--- a/cmd/exo/ls.go
+++ b/cmd/exo/ls.go
@@ -27,7 +27,7 @@ var lsCmd = &cobra.Command{
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.DescribeComponents(ctx, &api.DescribeComponentsInput{
 			Types: lsFlags.Types,
 		})

--- a/cmd/exo/new_container.go
+++ b/cmd/exo/new_container.go
@@ -146,7 +146,7 @@ exo flags and options for your docker container command.
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		name := args[0]
 

--- a/cmd/exo/new_network.go
+++ b/cmd/exo/new_network.go
@@ -47,7 +47,7 @@ docker network create <name>
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		name := args[0]
 

--- a/cmd/exo/new_process.go
+++ b/cmd/exo/new_process.go
@@ -39,7 +39,7 @@ before the program name.
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		name := args[0]
 		args = args[1:]

--- a/cmd/exo/new_volume.go
+++ b/cmd/exo/new_volume.go
@@ -34,7 +34,7 @@ docker volume create <name>
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 
 		name := args[0]
 

--- a/cmd/exo/ps.go
+++ b/cmd/exo/ps.go
@@ -22,7 +22,7 @@ var psCmd = &cobra.Command{
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.DescribeProcesses(ctx, &api.DescribeProcessesInput{})
 		if err != nil {
 			return err

--- a/cmd/exo/rm.go
+++ b/cmd/exo/rm.go
@@ -21,7 +21,7 @@ var rmCmd = &cobra.Command{
 		checkOrEnsureServer()
 		cl := newClient()
 		kernel := cl.Kernel()
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.DeleteComponents(ctx, &api.DeleteComponentsInput{
 			Refs: args,
 		})

--- a/cmd/exo/run.go
+++ b/cmd/exo/run.go
@@ -38,7 +38,7 @@ If a workspace does not exist, one will be created in the current directory.
 		logger := logging.CurrentLogger(ctx)
 
 		// Ensure workspace.
-		workspace := mustFindWorkspace(ctx, cl)
+		workspace := mustResolveCurrentWorkspace(ctx, cl)
 		if workspace == nil {
 			output, err := cl.Kernel().CreateWorkspace(ctx, &api.CreateWorkspaceInput{
 				Root: cmdutil.MustGetwd(),

--- a/cmd/exo/state.go
+++ b/cmd/exo/state.go
@@ -44,7 +44,7 @@ var stateGetCmd = &cobra.Command{
 		checkOrEnsureServer()
 		cl := newClient()
 
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.GetComponentState(ctx, &api.GetComponentStateInput{Ref: componentRef})
 		if err != nil {
 			return err
@@ -71,7 +71,7 @@ var stateSetCmd = &cobra.Command{
 			return fmt.Errorf("reading state from stdin: %w", err)
 		}
 
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		_, err := workspace.SetComponentState(ctx, &api.SetComponentStateInput{
 			Ref:   componentRef,
 			State: jsonutil.MustMarshalString(newState),
@@ -91,7 +91,7 @@ var stateClearCmd = &cobra.Command{
 		checkOrEnsureServer()
 		cl := newClient()
 
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		_, err := workspace.SetComponentState(ctx, &api.SetComponentStateInput{
 			Ref:   componentRef,
 			State: "{}",
@@ -112,7 +112,7 @@ var stateEditCmd = &cobra.Command{
 		checkOrEnsureServer()
 		cl := newClient()
 
-		workspace := requireWorkspace(ctx, cl)
+		workspace := requireCurrentWorkspace(ctx, cl)
 		output, err := workspace.GetComponentState(ctx, &api.GetComponentStateInput{Ref: componentRef})
 		if err != nil {
 			return err

--- a/cmd/exo/workspace_destroy.go
+++ b/cmd/exo/workspace_destroy.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/deref/exo/internal/core/api"
 	"github.com/spf13/cobra"
 )
@@ -24,9 +26,17 @@ Deleting a workspace also deletes all resources in that workspace.`,
 		kernel := cl.Kernel()
 		var workspace api.Workspace
 		if len(args) < 1 {
-			workspace = requireWorkspace(ctx, cl)
+			workspace = requireCurrentWorkspace(ctx, cl)
 		} else {
-			workspace = cl.GetWorkspace(args[0])
+			ref := args[0]
+			var err error
+			workspace, err = resolveWorkspace(ctx, cl, ref)
+			if err != nil {
+				return fmt.Errorf("resolving workspace: %w", err)
+			}
+			if workspace == nil {
+				return fmt.Errorf("unresolved workspace ref: %q", ref)
+			}
 		}
 		output, err := workspace.Destroy(ctx, &api.DestroyInput{})
 		if err != nil {

--- a/internal/core/api/kernel.go
+++ b/internal/core/api/kernel.go
@@ -12,7 +12,7 @@ import (
 type Kernel interface {
 	CreateWorkspace(context.Context, *CreateWorkspaceInput) (*CreateWorkspaceOutput, error)
 	DescribeWorkspaces(context.Context, *DescribeWorkspacesInput) (*DescribeWorkspacesOutput, error)
-	FindWorkspace(context.Context, *FindWorkspaceInput) (*FindWorkspaceOutput, error)
+	ResolveWorkspace(context.Context, *ResolveWorkspaceInput) (*ResolveWorkspaceOutput, error)
 	// Debug method to test what happens when the service panics.
 	Panic(context.Context, *PanicInput) (*PanicOutput, error)
 	// Retrieves the installed and current version of exo.
@@ -41,11 +41,11 @@ type DescribeWorkspacesOutput struct {
 	Workspaces []WorkspaceDescription `json:"workspaces"`
 }
 
-type FindWorkspaceInput struct {
-	Path string `json:"path"`
+type ResolveWorkspaceInput struct {
+	Ref string `json:"ref"`
 }
 
-type FindWorkspaceOutput struct {
+type ResolveWorkspaceOutput struct {
 	ID *string `json:"id"`
 }
 
@@ -100,8 +100,8 @@ func BuildKernelMux(b *josh.MuxBuilder, factory func(req *http.Request) Kernel) 
 	b.AddMethod("describe-workspaces", func(req *http.Request) interface{} {
 		return factory(req).DescribeWorkspaces
 	})
-	b.AddMethod("find-workspace", func(req *http.Request) interface{} {
-		return factory(req).FindWorkspace
+	b.AddMethod("resolve-workspace", func(req *http.Request) interface{} {
+		return factory(req).ResolveWorkspace
 	})
 	b.AddMethod("panic", func(req *http.Request) interface{} {
 		return factory(req).Panic

--- a/internal/core/api/kernel.josh.hcl
+++ b/internal/core/api/kernel.josh.hcl
@@ -10,8 +10,8 @@ interface "kernel" {
     output "workspaces" "[]WorkspaceDescription" {}
   }
   
-  method "find-workspace" {
-    input "path" "string" {}
+  method "resolve-workspace" {
+    input "ref" "string" {}
 
     output "id" "*string" {}
   }

--- a/internal/core/client/kernel.go
+++ b/internal/core/client/kernel.go
@@ -31,8 +31,8 @@ func (c *Kernel) DescribeWorkspaces(ctx context.Context, input *api.DescribeWork
 	return
 }
 
-func (c *Kernel) FindWorkspace(ctx context.Context, input *api.FindWorkspaceInput) (output *api.FindWorkspaceOutput, err error) {
-	err = c.client.Invoke(ctx, "find-workspace", input, &output)
+func (c *Kernel) ResolveWorkspace(ctx context.Context, input *api.ResolveWorkspaceInput) (output *api.ResolveWorkspaceOutput, err error) {
+	err = c.client.Invoke(ctx, "resolve-workspace", input, &output)
 	return
 }
 

--- a/internal/core/server/kernel.go
+++ b/internal/core/server/kernel.go
@@ -59,14 +59,14 @@ func (kern *Kernel) DescribeWorkspaces(ctx context.Context, input *api.DescribeW
 	}, nil
 }
 
-func (kern *Kernel) FindWorkspace(ctx context.Context, input *api.FindWorkspaceInput) (*api.FindWorkspaceOutput, error) {
-	output, err := kern.Store.FindWorkspace(ctx, &state.FindWorkspaceInput{
-		Path: input.Path,
+func (kern *Kernel) ResolveWorkspace(ctx context.Context, input *api.ResolveWorkspaceInput) (*api.ResolveWorkspaceOutput, error) {
+	output, err := kern.Store.ResolveWorkspace(ctx, &state.ResolveWorkspaceInput{
+		Ref: input.Ref,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &api.FindWorkspaceOutput{
+	return &api.ResolveWorkspaceOutput{
 		ID: output.ID,
 	}, nil
 }

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -14,7 +14,7 @@ type Store interface {
 	DescribeWorkspaces(context.Context, *DescribeWorkspacesInput) (*DescribeWorkspacesOutput, error)
 	AddWorkspace(context.Context, *AddWorkspaceInput) (*AddWorkspaceOutput, error)
 	RemoveWorkspace(context.Context, *RemoveWorkspaceInput) (*RemoveWorkspaceOutput, error)
-	FindWorkspace(context.Context, *FindWorkspaceInput) (*FindWorkspaceOutput, error)
+	ResolveWorkspace(context.Context, *ResolveWorkspaceInput) (*ResolveWorkspaceOutput, error)
 	Resolve(context.Context, *ResolveInput) (*ResolveOutput, error)
 	DescribeComponents(context.Context, *DescribeComponentsInput) (*DescribeComponentsOutput, error)
 	AddComponent(context.Context, *AddComponentInput) (*AddComponentOutput, error)
@@ -45,11 +45,11 @@ type RemoveWorkspaceInput struct {
 type RemoveWorkspaceOutput struct {
 }
 
-type FindWorkspaceInput struct {
-	Path string `json:"path"`
+type ResolveWorkspaceInput struct {
+	Ref string `json:"ref"`
 }
 
-type FindWorkspaceOutput struct {
+type ResolveWorkspaceOutput struct {
 	ID *string `json:"id"`
 }
 
@@ -115,8 +115,8 @@ func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
 	b.AddMethod("remove-workspace", func(req *http.Request) interface{} {
 		return factory(req).RemoveWorkspace
 	})
-	b.AddMethod("find-workspace", func(req *http.Request) interface{} {
-		return factory(req).FindWorkspace
+	b.AddMethod("resolve-workspace", func(req *http.Request) interface{} {
+		return factory(req).ResolveWorkspace
 	})
 	b.AddMethod("resolve", func(req *http.Request) interface{} {
 		return factory(req).Resolve

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -17,8 +17,8 @@ interface "store" {
     input "id" "string" {}
   }
   
-  method "find-workspace" {
-    input "path" "string" {}
+  method "resolve-workspace" {
+    input "ref" "string" {}
 
     output "id" "*string" {}
   }

--- a/internal/core/state/client/store.go
+++ b/internal/core/state/client/store.go
@@ -36,8 +36,8 @@ func (c *Store) RemoveWorkspace(ctx context.Context, input *api.RemoveWorkspaceI
 	return
 }
 
-func (c *Store) FindWorkspace(ctx context.Context, input *api.FindWorkspaceInput) (output *api.FindWorkspaceOutput, err error) {
-	err = c.client.Invoke(ctx, "find-workspace", input, &output)
+func (c *Store) ResolveWorkspace(ctx context.Context, input *api.ResolveWorkspaceInput) (output *api.ResolveWorkspaceOutput, err error) {
+	err = c.client.Invoke(ctx, "resolve-workspace", input, &output)
 	return
 }
 


### PR DESCRIPTION
This lets you refer to workspaces by id or by filepaths. Makes the CLI
experience a bit more convenient. Espeically for `workspace destroy`.