### PR TITLE
stable dexo binary

### DIFF
--- a/script/dexo
+++ b/script/dexo
@@ -8,12 +8,11 @@ source "$( dirname "${BASH_SOURCE[0]}" )/.include"
 # configures the client to talk to the development instance of exo and can be
 # run from any working directory.
 
-pushd "$ROOT_DIR" > /dev/null
+(
+  cd "$ROOT_DIR"
+  go build -o "$EXO_DEV_HOME/bin/exo" ./cmd/exo
+)
 
-tmp_dir=$(mktemp -d -t tmp-dexo-XXXXXXX)
-trap 'rm -rf -- "$tmp_dir"' EXIT
+export EXO_HOME="$EXO_DEV_HOME"
 
-go build -o "$tmp_dir" ./cmd/exo
-
-popd > /dev/null
-EXO_HOME="$EXO_DEV_HOME" "$tmp_dir/exo" "$@"
+"$EXO_DEV_HOME/bin/exo" "$@"


### PR DESCRIPTION
The previous approach of using a trap to cleanup temporary files is
broken with respect to running supervise or other re-entrant commands
that run in the daemon and rely on os.Args[0] existing after the initial
command returns.

Explicitly using -o and the .dev directory won't leak temp files, which
is why the trap was previously included.