### PR TITLE
Strip new lines from docker

### DIFF
--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -28,12 +28,6 @@
     }
   });
 
-  // This trims the final newline character at the end of each log message,
-  // because the table layout already effectively adds one line break at
-  // the end of each message and this was causing bugs on some Linux systems.
-  const trimFinalNewline = (message: string) =>
-    message.replace(/((\n\r)|(\n)|(\r)|(\r\n))$/, '');
-
   // SEE NOTE [LOG_COMPONENTS]
   const trimLabel = (name: string) => name.replace(/(:err$)|(:out$)/g, '');
 </script>
@@ -52,7 +46,7 @@
         </td>
         <td class="name" title={event.name}>{trimLabel(event.name)}</td>
         <td>
-          <FormattedLogMessage message={trimFinalNewline(event.message)} />
+          <FormattedLogMessage message={event.message} />
         </td>
       </tr>
     {/each}

--- a/internal/logd/logd.go
+++ b/internal/logd/logd.go
@@ -107,9 +107,14 @@ func syslogToEvent(syslogMessage syslog.Message) (*api.AddEventInput, error) {
 		}
 	}
 
+	message := *rfc5425Message.Message
+	if message[len(message)-1] == '\n' {
+		message = message[:len(message)-1]
+	}
+
 	return &api.AddEventInput{
 		Log:       logName,
 		Timestamp: rfc5425Message.Timestamp.Format(chrono.RFC3339MicroUTC),
-		Message:   *rfc5425Message.Message,
+		Message:   message,
 	}, nil
 }

--- a/internal/logd/logd.go
+++ b/internal/logd/logd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/deref/exo/internal/chrono"
@@ -107,11 +108,7 @@ func syslogToEvent(syslogMessage syslog.Message) (*api.AddEventInput, error) {
 		}
 	}
 
-	message := *rfc5425Message.Message
-	if message[len(message)-1] == '\n' {
-		message = message[:len(message)-1]
-	}
-
+	message := strings.TrimSuffix(*rfc5425Message.Message, "\n")
 	return &api.AddEventInput{
 		Log:       logName,
 		Timestamp: rfc5425Message.Timestamp.Format(chrono.RFC3339MicroUTC),


### PR DESCRIPTION
This strips trailing new line characters received as logs from the docker daemon, fixing an issue with duplicated new lines in the UI.

Whilst this works, I still think this is the wrong fix. We're fixing a display issue by changing the way we process logs. In the same way that docker preserves the newline characters I think we should too. Now, instead of the clients having to strip the newlines, every provider will have to implement that logic.