### PR TITLE
Fix error with async image pull

### DIFF
--- a/cmd/exo/root.go
+++ b/cmd/exo/root.go
@@ -26,9 +26,7 @@ For more information, see https://exo.deref.io`,
 }
 
 // newContext creates a global context that is used as the top-level process context.
-// All request-specific contexts are derived from it. Any key added to the context
-// here needs to have a corresponding call to contextutil.RegisterContextCloner so
-// that we can copy these values from a request-specific context to an asynchronous one.
+// All request-specific contexts are derived from it.
 func newContext() context.Context {
 	ctx := context.Background()
 

--- a/cmd/exo/root.go
+++ b/cmd/exo/root.go
@@ -25,6 +25,10 @@ For more information, see https://exo.deref.io`,
 	},
 }
 
+// newContext creates a global context that is used as the top-level process context.
+// All request-specific contexts are derived from it. Any key added to the context
+// here needs to have a corresponding call to contextutil.RegisterContextCloner so
+// that we can copy these values from a request-specific context to an asynchronous one.
 func newContext() context.Context {
 	ctx := context.Background()
 

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -28,6 +28,7 @@ import (
 	"github.com/deref/exo/internal/providers/docker/components/volume"
 	"github.com/deref/exo/internal/providers/unix/components/process"
 	"github.com/deref/exo/internal/task"
+	"github.com/deref/exo/internal/util/contextutil"
 	"github.com/deref/exo/internal/util/errutil"
 	"github.com/deref/exo/internal/util/jsonutil"
 	"github.com/deref/exo/internal/util/logging"
@@ -467,11 +468,11 @@ func (ws *Workspace) createComponent(ctx context.Context, component manifest.Com
 		return "", fmt.Errorf("adding component: %w", err)
 	}
 
-	job := ws.TaskTracker.StartTask(ctx, "creating "+component.Name)
+	job := ws.TaskTracker.StartTask(contextutil.DeriveBackgroundContext(ctx), "creating "+component.Name)
 	go func() {
 		defer job.Finish()
 
-		if err := ws.control(ctx, api.ComponentDescription{
+		if err := ws.control(job, api.ComponentDescription{
 			// Construct a synthetic component description to avoid re-reading after
 			// the add. Only the fields needed by control are included.
 			// TODO: Store.AddComponent could return a component description?

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -468,7 +468,7 @@ func (ws *Workspace) createComponent(ctx context.Context, component manifest.Com
 		return "", fmt.Errorf("adding component: %w", err)
 	}
 
-	job := ws.TaskTracker.StartTask(contextutil.DeriveBackgroundContext(ctx), "creating "+component.Name)
+	job := ws.TaskTracker.StartTask(contextutil.WithoutCancel(ctx), "creating "+component.Name)
 	go func() {
 		defer job.Finish()
 

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -2,19 +2,11 @@ package telemetry
 
 import (
 	"context"
-
-	"github.com/deref/exo/internal/util/contextutil"
 )
 
 type contextKey int
 
 const telemetryKey contextKey = 1
-
-func init() {
-	contextutil.RegisterContextCloner(func(src, dest context.Context) context.Context {
-		return ContextWithTelemetry(dest, FromContext(src))
-	})
-}
 
 func ContextWithTelemetry(ctx context.Context, telemetry Telemetry) context.Context {
 	return context.WithValue(ctx, telemetryKey, telemetry)

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -1,10 +1,20 @@
 package telemetry
 
-import "context"
+import (
+	"context"
+
+	"github.com/deref/exo/internal/util/contextutil"
+)
 
 type contextKey int
 
 const telemetryKey contextKey = 1
+
+func init() {
+	contextutil.RegisterContextCloner(func(src, dest context.Context) context.Context {
+		return ContextWithTelemetry(dest, FromContext(src))
+	})
+}
 
 func ContextWithTelemetry(ctx context.Context, telemetry Telemetry) context.Context {
 	return context.WithValue(ctx, telemetryKey, telemetry)

--- a/internal/util/contextutil/contextutil.go
+++ b/internal/util/contextutil/contextutil.go
@@ -1,0 +1,27 @@
+package contextutil
+
+import "context"
+
+type cloneFunc = func(src, dest context.Context) context.Context
+
+var cloneFuncs []cloneFunc
+
+// DeriveBackgroundContext creates a new context from `ctx` that contains all of the global
+// dependencies present in `ctx` but does not have any cancellation or timeout associated
+// with it. This is useful when we have a context tied to some request, and we need to spawn
+// an asynchronous job that may still need access to the context global values.
+//
+// Note that to clone the values from the old context to the new context, a module needs to
+// call RegisterContextCloner with a function that is able to copy the context global that
+// it manages from the old context to the new one.
+func DeriveBackgroundContext(ctx context.Context) context.Context {
+	newCtx := context.Background()
+	for _, cf := range cloneFuncs {
+		newCtx = cf(ctx, newCtx)
+	}
+	return newCtx
+}
+
+func RegisterContextCloner(fn cloneFunc) {
+	cloneFuncs = append(cloneFuncs, fn)
+}

--- a/internal/util/contextutil/contextutil.go
+++ b/internal/util/contextutil/contextutil.go
@@ -1,27 +1,32 @@
 package contextutil
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
-type cloneFunc = func(src, dest context.Context) context.Context
-
-var cloneFuncs []cloneFunc
-
-// DeriveBackgroundContext creates a new context from `ctx` that contains all of the global
-// dependencies present in `ctx` but does not have any cancellation or timeout associated
-// with it. This is useful when we have a context tied to some request, and we need to spawn
-// an asynchronous job that may still need access to the context global values.
-//
-// Note that to clone the values from the old context to the new context, a module needs to
-// call RegisterContextCloner with a function that is able to copy the context global that
-// it manages from the old context to the new one.
-func DeriveBackgroundContext(ctx context.Context) context.Context {
-	newCtx := context.Background()
-	for _, cf := range cloneFuncs {
-		newCtx = cf(ctx, newCtx)
-	}
-	return newCtx
+type noCancel struct {
+	ctx context.Context
 }
 
-func RegisterContextCloner(fn cloneFunc) {
-	cloneFuncs = append(cloneFuncs, fn)
+func (c noCancel) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c noCancel) Done() <-chan struct{} {
+	return nil
+}
+
+func (c noCancel) Err() error {
+	return nil
+}
+
+func (c noCancel) Value(key interface{}) interface{} {
+	return c.ctx.Value(key)
+}
+
+// WithoutCancel creates a new context from `ctx` that is never cancelled
+// and never times out.
+func WithoutCancel(ctx context.Context) context.Context {
+	return noCancel{ctx: ctx}
 }

--- a/internal/util/logging/context.go
+++ b/internal/util/logging/context.go
@@ -2,19 +2,11 @@ package logging
 
 import (
 	"context"
-
-	"github.com/deref/exo/internal/util/contextutil"
 )
 
 type contextKey int
 
 const loggerKey contextKey = 1
-
-func init() {
-	contextutil.RegisterContextCloner(func(src, dest context.Context) context.Context {
-		return ContextWithLogger(dest, CurrentLogger(src))
-	})
-}
 
 func ContextWithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)

--- a/internal/util/logging/context.go
+++ b/internal/util/logging/context.go
@@ -1,10 +1,20 @@
 package logging
 
-import "context"
+import (
+	"context"
+
+	"github.com/deref/exo/internal/util/contextutil"
+)
 
 type contextKey int
 
 const loggerKey contextKey = 1
+
+func init() {
+	contextutil.RegisterContextCloner(func(src, dest context.Context) context.Context {
+		return ContextWithLogger(dest, CurrentLogger(src))
+	})
+}
 
 func ContextWithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)


### PR DESCRIPTION
This PR fixes the issue reported by @BenElgar in Slack where images that were not already present on the host caused the CreateContainer task to fail. This happened because the task was handed a context that would be cancelled by the time we used it to try to download a new image.