### PR TITLE
Amplitude analytics

### DIFF
--- a/AMPLITUDE_API_KEY
+++ b/AMPLITUDE_API_KEY
@@ -1,0 +1,1 @@
+Since the API key is semi-private, this file is replaced in CI with the real API key.

--- a/about.go
+++ b/about.go
@@ -7,11 +7,13 @@ import (
 const (
 	CheckVersionEndpoint = "https://exo.deref.io/latest-version"
 	UpdateScriptEndpoint = "https://exo.deref.io/install"
-	TelemetryEndpoint    = "https://exo.deref.io/api/telemetry"
 )
 
 //go:embed VERSION
 var Version string
+
+//go:embed AMPLITUDE_API_KEY
+var AmplitudeAPIKey string
 
 //go:embed NOTICES.md
 //go:embed LICENSE

--- a/cmd/exo/root.go
+++ b/cmd/exo/root.go
@@ -31,7 +31,12 @@ func newContext() context.Context {
 	logger := logging.Default()
 	ctx = logging.ContextWithLogger(ctx, logger)
 
-	tel := telemetry.New(ctx, &cfg.Telemetry)
+	// This telemetry object will be replaced by one that includes the
+	// installation ID when the daemon starts. For one-off commands,
+	// it is fine for the ID to not be populated.
+	tel := telemetry.New(ctx, telemetry.Config{
+		Disable: cfg.Telemetry.Disable,
+	})
 	ctx = telemetry.ContextWithTelemetry(ctx, tel)
 
 	return ctx

--- a/internal/chrono/chrono.go
+++ b/internal/chrono/chrono.go
@@ -18,6 +18,10 @@ func NowNano(ctx context.Context) int64 {
 	return Now(ctx).UnixNano()
 }
 
+func NowMillisecond(ctx context.Context) int64 {
+	return Now(ctx).UnixNano() / int64(time.Millisecond)
+}
+
 func NowString(ctx context.Context) string {
 	return IsoNano(Now(ctx))
 }

--- a/internal/core/server/handler.go
+++ b/internal/core/server/handler.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Config struct {
+	DeviceID    string
 	VarDir      string
 	Store       state.Store
 	SyslogPort  uint
@@ -27,6 +28,7 @@ func BuildRootMux(prefix string, cfg *Config) *http.ServeMux {
 	endKernel := b.Begin("kernel")
 	api.BuildKernelMux(b, func(req *http.Request) api.Kernel {
 		return &Kernel{
+			DeviceID:    cfg.DeviceID,
 			VarDir:      cfg.VarDir,
 			Store:       cfg.Store,
 			TaskTracker: cfg.TaskTracker,

--- a/internal/core/server/kernel.go
+++ b/internal/core/server/kernel.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Kernel struct {
+	DeviceID    string
 	VarDir      string
 	Store       state.Store
 	TaskTracker *task.TaskTracker
@@ -96,7 +97,7 @@ func (kern *Kernel) Upgrade(ctx context.Context, input *api.UpgradeInput) (*api.
 	if upgrade.IsManaged {
 		return nil, errutil.WithHTTPStatus(http.StatusBadRequest, errors.New("exo installed with system package manager"))
 	}
-	err := upgrade.UpgradeSelf()
+	err := upgrade.UpgradeSelf(kern.DeviceID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -20,8 +20,8 @@ type Store interface {
 	AddComponent(context.Context, *AddComponentInput) (*AddComponentOutput, error)
 	PatchComponent(context.Context, *PatchComponentInput) (*PatchComponentOutput, error)
 	RemoveComponent(context.Context, *RemoveComponentInput) (*RemoveComponentOutput, error)
-	// Ensure that one-time initialization has been completed. This is safe to call whenever the server is restarted.
-	EnsureInstallation(context.Context, *EnsureInstallationInput) (*EnsureInstallationOutput, error)
+	// Ensure that one-time device initialization has been completed. This is safe to call whenever the server is restarted.
+	EnsureDevice(context.Context, *EnsureDeviceInput) (*EnsureDeviceOutput, error)
 }
 
 type DescribeWorkspacesInput struct {
@@ -107,11 +107,11 @@ type RemoveComponentInput struct {
 type RemoveComponentOutput struct {
 }
 
-type EnsureInstallationInput struct {
+type EnsureDeviceInput struct {
 }
 
-type EnsureInstallationOutput struct {
-	InstallationID string `json:"installationId"`
+type EnsureDeviceOutput struct {
+	DeviceID string `json:"deviceId"`
 }
 
 func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
@@ -142,8 +142,8 @@ func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
 	b.AddMethod("remove-component", func(req *http.Request) interface{} {
 		return factory(req).RemoveComponent
 	})
-	b.AddMethod("ensure-installation", func(req *http.Request) interface{} {
-		return factory(req).EnsureInstallation
+	b.AddMethod("ensure-device", func(req *http.Request) interface{} {
+		return factory(req).EnsureDevice
 	})
 }
 

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -111,6 +111,7 @@ type EnsureInstallationInput struct {
 }
 
 type EnsureInstallationOutput struct {
+	InstallationID string `json:"installationId"`
 }
 
 func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -20,6 +20,8 @@ type Store interface {
 	AddComponent(context.Context, *AddComponentInput) (*AddComponentOutput, error)
 	PatchComponent(context.Context, *PatchComponentInput) (*PatchComponentOutput, error)
 	RemoveComponent(context.Context, *RemoveComponentInput) (*RemoveComponentOutput, error)
+	// Ensure that one-time initialization has been completed. This is safe to call whenever the server is restarted.
+	EnsureInstallation(context.Context, *EnsureInstallationInput) (*EnsureInstallationOutput, error)
 }
 
 type DescribeWorkspacesInput struct {
@@ -105,6 +107,12 @@ type RemoveComponentInput struct {
 type RemoveComponentOutput struct {
 }
 
+type EnsureInstallationInput struct {
+}
+
+type EnsureInstallationOutput struct {
+}
+
 func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
 	b.AddMethod("describe-workspaces", func(req *http.Request) interface{} {
 		return factory(req).DescribeWorkspaces
@@ -132,6 +140,9 @@ func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
 	})
 	b.AddMethod("remove-component", func(req *http.Request) interface{} {
 		return factory(req).RemoveComponent
+	})
+	b.AddMethod("ensure-installation", func(req *http.Request) interface{} {
+		return factory(req).EnsureInstallation
 	})
 }
 

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -64,6 +64,8 @@ interface "store" {
 
   method "ensure-installation" {
     doc = "Ensure that one-time initialization has been completed. This is safe to call whenever the server is restarted."
+
+    output "installation-id" "string" {}
   }
 }
 

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -62,6 +62,9 @@ interface "store" {
     input "id" "string" {}
   }
 
+  method "ensure-installation" {
+    doc = "Ensure that one-time initialization has been completed. This is safe to call whenever the server is restarted."
+  }
 }
 
 struct "workspace-description" {

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -62,10 +62,10 @@ interface "store" {
     input "id" "string" {}
   }
 
-  method "ensure-installation" {
-    doc = "Ensure that one-time initialization has been completed. This is safe to call whenever the server is restarted."
+  method "ensure-device" {
+    doc = "Ensure that one-time device initialization has been completed. This is safe to call whenever the server is restarted."
 
-    output "installation-id" "string" {}
+    output "device-id" "string" {}
   }
 }
 

--- a/internal/core/state/client/store.go
+++ b/internal/core/state/client/store.go
@@ -66,7 +66,7 @@ func (c *Store) RemoveComponent(ctx context.Context, input *api.RemoveComponentI
 	return
 }
 
-func (c *Store) EnsureInstallation(ctx context.Context, input *api.EnsureInstallationInput) (output *api.EnsureInstallationOutput, err error) {
-	err = c.client.Invoke(ctx, "ensure-installation", input, &output)
+func (c *Store) EnsureDevice(ctx context.Context, input *api.EnsureDeviceInput) (output *api.EnsureDeviceOutput, err error) {
+	err = c.client.Invoke(ctx, "ensure-device", input, &output)
 	return
 }

--- a/internal/core/state/client/store.go
+++ b/internal/core/state/client/store.go
@@ -65,3 +65,8 @@ func (c *Store) RemoveComponent(ctx context.Context, input *api.RemoveComponentI
 	err = c.client.Invoke(ctx, "remove-component", input, &output)
 	return
 }
+
+func (c *Store) EnsureInstallation(ctx context.Context, input *api.EnsureInstallationInput) (output *api.EnsureInstallationOutput, err error) {
+	err = c.client.Invoke(ctx, "ensure-installation", input, &output)
+	return
+}

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/deref/exo/internal/core/state/api"
 	state "github.com/deref/exo/internal/core/state/api"
 	"github.com/deref/exo/internal/deps"
+	"github.com/deref/exo/internal/gensym"
 	"github.com/deref/exo/internal/util/atom"
 	"github.com/deref/exo/internal/util/errutil"
 	"github.com/deref/exo/internal/util/pathutil"
@@ -32,6 +33,7 @@ var _ state.Store = (*Store)(nil)
 type Root struct {
 	Workspaces          map[string]*Workspace `json:"workspaces"`          // Keyed by ID.
 	ComponentWorkspaces map[string]string     `json:"componentWorkspaces"` // Component ID -> Workspace ID.
+	InstallationID      string                `json:"installationId"`
 }
 
 type Component struct {
@@ -442,4 +444,18 @@ func (sto *Store) RemoveComponent(ctx context.Context, input *state.RemoveCompon
 		return nil, err
 	}
 	return &state.RemoveComponentOutput{}, nil
+}
+
+func (sto *Store) EnsureInstallation(ctx context.Context, input *state.EnsureInstallationInput) (*state.EnsureInstallationOutput, error) {
+	_, err := sto.swap(func(root *Root) error {
+		if root.InstallationID != "" {
+			return nil
+		}
+		root.InstallationID = gensym.RandomBase32()
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &state.EnsureInstallationOutput{}, nil
 }

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -447,15 +447,22 @@ func (sto *Store) RemoveComponent(ctx context.Context, input *state.RemoveCompon
 }
 
 func (sto *Store) EnsureInstallation(ctx context.Context, input *state.EnsureInstallationInput) (*state.EnsureInstallationOutput, error) {
+	var installationID string
+
 	_, err := sto.swap(func(root *Root) error {
 		if root.InstallationID != "" {
+			installationID = root.InstallationID
 			return nil
 		}
-		root.InstallationID = gensym.RandomBase32()
+		installationID = gensym.RandomBase32()
+		root.InstallationID = installationID
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &state.EnsureInstallationOutput{}, nil
+
+	return &state.EnsureInstallationOutput{
+		InstallationID: installationID,
+	}, nil
 }

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -33,7 +33,7 @@ var _ state.Store = (*Store)(nil)
 type Root struct {
 	Workspaces          map[string]*Workspace `json:"workspaces"`          // Keyed by ID.
 	ComponentWorkspaces map[string]string     `json:"componentWorkspaces"` // Component ID -> Workspace ID.
-	InstallationID      string                `json:"installationId"`
+	DeviceID            string                `json:"deviceId"`
 }
 
 type Component struct {
@@ -446,12 +446,12 @@ func (sto *Store) RemoveComponent(ctx context.Context, input *state.RemoveCompon
 	return &state.RemoveComponentOutput{}, nil
 }
 
-func (sto *Store) EnsureInstallation(ctx context.Context, input *state.EnsureInstallationInput) (*state.EnsureInstallationOutput, error) {
-	var installationID string
+func (sto *Store) EnsureDevice(ctx context.Context, input *state.EnsureDeviceInput) (*state.EnsureDeviceOutput, error) {
+	var deviceID string
 
 	_, err := sto.swap(func(root *Root) error {
-		if root.InstallationID != "" {
-			installationID = root.InstallationID
+		if root.DeviceID != "" {
+			deviceID = root.DeviceID
 			return nil
 		}
 		installationID = gensym.RandomBase32()
@@ -462,7 +462,7 @@ func (sto *Store) EnsureInstallation(ctx context.Context, input *state.EnsureIns
 		return nil, err
 	}
 
-	return &state.EnsureInstallationOutput{
-		InstallationID: installationID,
+	return &state.EnsureDeviceOutput{
+		DeviceID: deviceID,
 	}, nil
 }

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -467,7 +467,7 @@ func (sto *Store) EnsureDevice(ctx context.Context, input *state.EnsureDeviceInp
 		case os.IsNotExist(err):
 			deviceID = gensym.RandomBase32()
 		case err != nil:
-			return err
+			return fmt.Errorf("reading device id file: %w", err)
 		default:
 			deviceID = string(deviceIDFile)
 		}

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -107,6 +107,7 @@ func RunServer(ctx context.Context, flags map[string]string) {
 	})
 	ctx = telemetry.ContextWithTelemetry(ctx, tel)
 	tel.StartSession(ctx)
+	tel.SendEvent(ctx, telemetry.SystemInfoIdentifiedEvent())
 
 	dockerClient, err := docker.NewClientWithOpts()
 	if err != nil {
@@ -119,6 +120,7 @@ func RunServer(ctx context.Context, flags map[string]string) {
 	}
 
 	kernelCfg := &kernel.Config{
+		DeviceID:    ensureDeviceOut.DeviceID,
 		VarDir:      cfg.VarDir,
 		Store:       store,
 		SyslogPort:  cfg.Log.SyslogPort,

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/deref/exo/internal/config"
 	"github.com/deref/exo/internal/core/server"
 	kernel "github.com/deref/exo/internal/core/server"
+	state "github.com/deref/exo/internal/core/state/api"
 	"github.com/deref/exo/internal/core/state/statefile"
 	"github.com/deref/exo/internal/gensym"
 	"github.com/deref/exo/internal/logd"
@@ -94,6 +95,9 @@ func RunServer(ctx context.Context, flags map[string]string) {
 
 	statePath := filepath.Join(cfg.VarDir, "state.json")
 	store := statefile.New(statePath)
+	if _, err := store.EnsureInstallation(ctx, &state.EnsureInstallationInput{}); err != nil {
+		cmdutil.Fatalf("failed to initialize exo installation: %v", err)
+	}
 
 	dockerClient, err := docker.NewClientWithOpts()
 	if err != nil {

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -91,15 +91,19 @@ func RunServer(ctx context.Context, flags map[string]string) {
 	}
 
 	statePath := filepath.Join(cfg.VarDir, "state.json")
-	store := statefile.New(statePath)
-	insureInstallationOut, err := store.EnsureInstallation(ctx, &state.EnsureInstallationInput{})
+	deviceIDPath := filepath.Join(cfg.VarDir, "deviceid")
+	store := statefile.New(statefile.Config{
+		StoreFilename:    statePath,
+		DeviceIDFilename: deviceIDPath,
+	})
+	ensureDeviceOut, err := store.EnsureDevice(ctx, &state.EnsureDeviceInput{})
 	if err != nil {
 		cmdutil.Fatalf("failed to initialize exo installation: %v", err)
 	}
 
 	tel := telemetry.New(ctx, telemetry.Config{
-		Disable:        cfg.Telemetry.Disable,
-		InstallationID: insureInstallationOut.InstallationID,
+		Disable:  cfg.Telemetry.Disable,
+		DeviceID: ensureDeviceOut.DeviceID,
 	})
 	ctx = telemetry.ContextWithTelemetry(ctx, tel)
 	tel.StartSession(ctx)

--- a/internal/telemetry/amplitude.go
+++ b/internal/telemetry/amplitude.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	amplitudeURL           = "https://api2.amplitude.com/2/httpapi"
+	eventChannelBufferSize = 8
+	eventBufferSize        = 32
+)
+
+var eventSendInterval = time.Second * 15
+
+// AmplitudeClient was inlfuenced by https://github.com/savaki/amplitude-go
+// but uses the version 2 HTTP API.
+type AmplitudeClient struct {
+	apiKey string
+	events chan Event
+	flush  chan chan struct{}
+	client *http.Client
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewAmplitudeClient(ctx context.Context, client *http.Client, apiKey string) *AmplitudeClient {
+	ctx, cancel := context.WithCancel(ctx)
+	ac := &AmplitudeClient{
+		apiKey: apiKey,
+		events: make(chan Event, eventChannelBufferSize),
+		flush:  make(chan chan struct{}),
+		ctx:    ctx,
+		cancel: cancel,
+		client: client,
+	}
+
+	go ac.run()
+
+	return ac
+}
+
+func (a *AmplitudeClient) Publish(evt Event) error {
+	select {
+	case a.events <- evt:
+		return nil
+	default:
+		return fmt.Errorf("event channel buffer of size %d is full", eventChannelBufferSize)
+	}
+}
+
+func (a *AmplitudeClient) Flush() {
+	notify := make(chan struct{})
+	defer close(notify)
+
+	a.flush <- notify
+	// Wait for flush to complete.
+	<-notify
+}
+
+func (a *AmplitudeClient) Close() {
+	a.Flush()
+	a.cancel()
+}
+
+func (a *AmplitudeClient) run() {
+	timer := time.NewTimer(eventSendInterval)
+
+	buffer := make([]Event, eventBufferSize)
+	idx := 0
+	doPublish := func() {
+		if idx > 0 {
+			a.publish(buffer[0:idx])
+			idx = 0
+		}
+	}
+
+	for {
+		timer.Reset(eventSendInterval)
+		select {
+		case <-a.ctx.Done():
+			return
+
+		case <-timer.C:
+			doPublish()
+
+		case evt := <-a.events:
+			buffer[idx] = evt
+			idx++
+			if idx == eventBufferSize {
+				doPublish()
+			}
+
+		case notify := <-a.flush:
+			doPublish()
+			notify <- struct{}{}
+		}
+	}
+}
+
+func (a *AmplitudeClient) publish(events []Event) error {
+	var buf bytes.Buffer
+	e := json.NewEncoder(&buf)
+	if err := e.Encode(UploadRequest{
+		APIKey: a.apiKey,
+		Events: events,
+	}); err != nil {
+		return fmt.Errorf("serializing upload request: %w", err)
+	}
+
+	res, err := a.client.Post(amplitudeURL, "application/json", &buf)
+	if err != nil {
+		return fmt.Errorf("performing telemetry request: %w", err)
+	}
+	defer res.Body.Close()
+	// TODO: Do something with response, potentially log errors, etc.
+
+	return nil
+}
+
+type UploadRequest struct {
+	APIKey string  `json:"api_key"`
+	Events []Event `json:"events"`
+}

--- a/internal/telemetry/default.go
+++ b/internal/telemetry/default.go
@@ -20,7 +20,7 @@ import (
 type defaultTelemetry struct {
 	ctx            context.Context
 	client         *http.Client
-	installationID string
+	deviceID       string
 	sessionID      string
 	operationGauge *SummaryGauge
 

--- a/internal/telemetry/default.go
+++ b/internal/telemetry/default.go
@@ -13,15 +13,14 @@ import (
 	"unsafe"
 
 	"github.com/deref/exo"
-	"github.com/deref/exo/internal/config"
 	"github.com/deref/exo/internal/util/cacheutil"
 	"github.com/deref/exo/internal/util/logging"
 )
 
 type defaultTelemetry struct {
 	ctx            context.Context
-	cfg            *config.TelemetryConfig
 	client         *http.Client
+	installationID string
 	sessionID      string
 	operationGauge *SummaryGauge
 

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,46 +1,53 @@
 package telemetry
 
-import "github.com/deref/exo"
+import (
+	"runtime"
 
-type event interface {
-	ID() string
-	Payload() map[string]interface{}
+	"github.com/deref/exo"
+)
+
+type Event struct {
+	// Set by event constructor.
+	Type            string                 `json:"event_type"`
+	EventProperties map[string]interface{} `json:"event_properties,omitempty"`
+	UserProperties  map[string]interface{} `json:"user_properties,omitempty"`
+	Platform        string                 `json:"platform,omitempty"`
+	OSName          string                 `json:"os_name,omitempty"`
+	OSVersion       string                 `json:"os_version,omitempty"`
+	AppVersion      string                 `json:"app_version,omitempty"`
+
+	// Set by telemetry.
+	DeviceID  string `json:"device_id"`
+	SessionID int64  `json:"session_id"`
+	EventID   int    `json:"event_id"`
+	Time      int64  `json:"time"`
 }
 
-type eventRequest struct {
-	ID      string
-	Payload string
-}
-
-type SystemInfoIdentified struct {
-}
-
-func (e *SystemInfoIdentified) ID() string {
-	return "TODO"
-}
-
-func (e *SystemInfoIdentified) Payload() map[string]interface{} {
-	return map[string]interface{}{
-		"some": "data",
-		"goes": "here",
+func SystemInfoIdentifiedEvent() Event {
+	return Event{
+		Type:       "system-info-identified",
+		Platform:   runtime.GOARCH,
+		OSName:     runtime.GOOS,
+		AppVersion: exo.Version,
+		EventProperties: map[string]interface{}{
+			"cpu_count": runtime.NumCPU(),
+		},
 	}
 }
 
-type OperationsPerformed struct {
-	Operation       string
-	Success         bool
-	DurationSummary SummaryStatistics
-}
-
-func (e *OperationsPerformed) ID() string {
-	return "a20fc050-ba26-4f05-832a-7d42283d1888"
-}
-
-func (e *OperationsPerformed) Payload() map[string]interface{} {
-	return map[string]interface{}{
-		"exoVersion": exo.Version,
-		"operation":  e.Operation,
-		"success":    e.Success,
-		"summary":    e.DurationSummary,
+func OperationsPerformedEvent(operation string, success bool, duration SummaryStatistics) Event {
+	return Event{
+		Type: "operations-performed",
+		EventProperties: map[string]interface{}{
+			"operation":       operation,
+			"success":         success,
+			"occurrences":     duration.Count,
+			"duration_max":    duration.Max,
+			"duration_min":    duration.Min,
+			"duration_mean":   duration.Mean,
+			"duration_median": duration.Median,
+			"duration_stddev": duration.StdDev,
+			"duration_sum":    duration.Sum,
+		},
 	}
 }

--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -17,7 +17,7 @@ func (t *noOpTelemetry) StartSession(_ context.Context) {
 	// Do nothing.
 }
 
-func (t *noOpTelemetry) SendEvent(_ context.Context, _ event) {
+func (t *noOpTelemetry) SendEvent(_ context.Context, _ Event) {
 	// Do nothing.
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -18,8 +18,8 @@ type Telemetry interface {
 }
 
 type Config struct {
-	Disable        bool
-	InstallationID string
+	Disable  bool
+	DeviceID string
 }
 
 func New(ctx context.Context, cfg Config) Telemetry {
@@ -28,8 +28,8 @@ func New(ctx context.Context, cfg Config) Telemetry {
 	}
 
 	t := &defaultTelemetry{
-		ctx:            ctx,
-		installationID: cfg.InstallationID,
+		ctx:      ctx,
+		deviceID: cfg.DeviceID,
 		client: &http.Client{
 			Timeout: time.Second * 5,
 		},

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/deref/exo/internal/config"
 	"github.com/deref/exo/internal/util/cacheutil"
 )
 
@@ -18,14 +17,19 @@ type Telemetry interface {
 	RecordOperation(OperationInvocation)
 }
 
-func New(ctx context.Context, cfg *config.TelemetryConfig) Telemetry {
+type Config struct {
+	Disable        bool
+	InstallationID string
+}
+
+func New(ctx context.Context, cfg Config) Telemetry {
 	if cfg.Disable {
 		return &noOpTelemetry{}
 	}
 
 	t := &defaultTelemetry{
-		ctx: ctx,
-		cfg: cfg,
+		ctx:            ctx,
+		installationID: cfg.InstallationID,
 		client: &http.Client{
 			Timeout: time.Second * 5,
 		},

--- a/internal/upgrade/autoinstalled.go
+++ b/internal/upgrade/autoinstalled.go
@@ -15,14 +15,14 @@ import (
 
 const IsManaged = false
 
-func UpgradeSelf() error {
+func UpgradeSelf(deviceID string) error {
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
 		return fmt.Errorf("creating temporary file: %w", err)
 	}
 	defer os.Remove(tmpfile.Name())
 
-	resp, err := http.Get(exo.UpdateScriptEndpoint)
+	resp, err := http.Get(fmt.Sprintf("%s?id=%s", exo.UpdateScriptEndpoint, deviceID))
 	if err != nil {
 		return fmt.Errorf("fetching update script: %w", err)
 	}

--- a/internal/upgrade/managed.go
+++ b/internal/upgrade/managed.go
@@ -6,7 +6,7 @@ import "fmt"
 
 const IsManaged = true
 
-func UpgradeSelf() error {
+func UpgradeSelf(deviceID string) error {
 	fmt.Println(`This version of exo was installed via a package manager and does not support self-upgrade. Please use your package manager to update.
 
 Alternatively, you may uninstall exo using your system's package manager and download the latest version with:


### PR DESCRIPTION
Hook up telemetry to send to Amplitude Analytics:
- Maintain a device ID that is used as a unique identifier for all events from a particular installation.
  - Send this device ID in the upgrade requests so that the API that serves the install script can attribute the upgrade to that user.
- Report very basic system information on startup (os, architecture, cpu count)
- Update the default telemetry implementation to use Amplitude instead of the previous bespoke solution.