### PR TITLE
New Project UI

### DIFF
--- a/gui/src/routes.ts
+++ b/gui/src/routes.ts
@@ -1,5 +1,7 @@
 import Home from './pages/Home.svelte';
-import NewWorkspace from './pages/NewWorkspace.svelte';
+import NewWorkspace from './pages/NewWorkspace.svelte'; // Delete this after New Project flow is ready
+import NewProject from './pages/NewProject.svelte';
+import NewProjectConfig from './pages/NewProjectConfig.svelte';
 import Workspace from './pages/Workspace.svelte';
 import WorkspaceComponents from './pages/WorkspaceComponents.svelte';
 import WorkspaceVariables from './pages/WorkspaceVariables.svelte';
@@ -18,7 +20,9 @@ import NotFound from './pages/NotFound.svelte';
 
 export default {
   '/': Home,
-  '/new-workspace': NewWorkspace,
+  '/new-workspace': NewWorkspace, // Delete this after New Project flow is ready
+  '/new-project': NewProject,
+  '/new-project/:starter': NewProjectConfig,
   '/workspaces/:workspace': Workspace,
   '/workspaces/:workspace/components': WorkspaceComponents,
   '/workspaces/:workspace/variables': WorkspaceVariables,


### PR DESCRIPTION
This PR will contain GUI pages to enable the creation of new Projects entirely within the GUI, including:

- Selection of a "starter" or "template" e.g. "Empty project" or "Next+Prisma+Postgres app"
- Selection of a parent directory + naming of the project (also the new directory name)
- Triggering the underlying creation process and showing a loading screen until the new project is ready