### PR TITLE
Put terminal in to "raw mode" when tailing logs.

### DIFF
--- a/cmd/exo/logs.go
+++ b/cmd/exo/logs.go
@@ -80,7 +80,7 @@ func runTailLogsReader(ctx context.Context, cancel func()) error {
 		switch press.Key {
 		// Clear screen.
 		case terminal.KeyCtrlL:
-			fmt.Print("\033[2J")
+			fmt.Print("\033[2J\033[1;1H")
 
 		// Quit.
 		case terminal.KeyCtrlC, 'q':

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20210608160410-67692ebc98de
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Nerdmaster/terminal v0.12.1
 	github.com/alessio/shellescape v1.4.1
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59
 	github.com/containerd/containerd v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/Microsoft/hcsshim/test v0.0.0-20200826032352-301c83a30e7c/go.mod h1:3
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Nerdmaster/terminal v0.12.1 h1:DGb3ya55nZdqdBMjWQHNF5mHYHS2eJgYLqmw3KnE1cQ=
+github.com/Nerdmaster/terminal v0.12.1/go.mod h1:Dg6++m3aF+P/l8RdYb/2N6zK3CqvUfzhBreUNEWuQ8M=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/internal/util/term/raw.go
+++ b/internal/util/term/raw.go
@@ -1,0 +1,60 @@
+package term
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/Nerdmaster/terminal"
+)
+
+type RawMode struct {
+	FD uintptr
+
+	oldState *terminal.State
+}
+
+func (raw *RawMode) Enter() error {
+	if raw.oldState != nil {
+		return errors.New("already entered raw mode")
+	}
+	var err error
+	raw.oldState, err = terminal.MakeRaw(int(raw.FD))
+	return err
+}
+
+func (raw *RawMode) Exit() error {
+	if raw.oldState == nil {
+		return errors.New("terminal state unknown")
+	}
+	err := terminal.Restore(int(raw.FD), raw.oldState)
+	if err == syscall.Errno(0) {
+		// terminal.Restore does not properly transform errorno=0 to nil errors.
+		err = nil
+	}
+	if err != nil {
+		return err
+	}
+	raw.oldState = nil
+	return nil
+}
+
+// Based on NetHack: <https://nethackwiki.com/wiki/%5EZ#cite_note-1>.
+func (raw *RawMode) Suspend() error {
+	if err := raw.Exit(); err != nil {
+		return fmt.Errorf("exiting raw mode: %w", err)
+	}
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGCONT)
+	if err := syscall.Kill(0, syscall.SIGSTOP); err != nil {
+		return fmt.Errorf("signally process to stop: %w", err)
+	}
+	<-c
+	signal.Ignore(syscall.SIGCONT)
+	if err := raw.Enter(); err != nil {
+		return fmt.Errorf("entering raw mode: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
In particular, this implements the CLI side of #347: handling of ^l.
cmd+k (for MacOS) already worked and remains so.