### PR TITLE
Fix panic when no log streams are selected

### DIFF
--- a/gui/src/components/logs/LocalLogProvider.svelte
+++ b/gui/src/components/logs/LocalLogProvider.svelte
@@ -24,12 +24,20 @@
       return;
     }
 
+    if (logs.length === 0) {
+      cursor = null;
+      events = [];
+      return;
+    }
+
     const res = await workspace.getEvents(logs, filterStr, {
       cursor,
       next: maxEvents,
     });
     cursor = res.nextCursor;
-    events = [...events, ...formatLogs(res.items, processIdToName)].slice(-maxEvents);
+    events = [...events, ...formatLogs(res.items, processIdToName)].slice(
+      -maxEvents,
+    );
 
     pollRefreshTimer = setTimeout(() => {
       pollRefreshTimer = null;

--- a/internal/eventd/sqlite/store.go
+++ b/internal/eventd/sqlite/store.go
@@ -111,6 +111,10 @@ const (
 )
 
 func (sto *Store) GetEvents(ctx context.Context, input *api.GetEventsInput) (*api.GetEventsOutput, error) {
+	if len(input.Streams) == 0 {
+		return nil, errors.New("no event streams specified")
+	}
+
 	limit := defaultNextLimit
 	reverse := false
 	if input.Next != nil {


### PR DESCRIPTION
The following panic was occurring when no log streams were selected in the UI:
```
16:05:59    server 2021/09/27 16:05:59 http: panic serving 127.0.0.1:39608: empty slice passed to 'in' query
16:05:59    server goroutine 15805 [running]:
16:05:59    server net/http.(*conn).serve.func1()
16:05:59    server      /usr/lib/go/src/net/http/server.go:1801 +0xb9
16:05:59    server panic({0xc80b20, 0xc00058f3f0})
16:05:59    server      /usr/lib/go/src/runtime/panic.go:1047 +0x266
16:05:59    server github.com/deref/exo/internal/eventd/sqlite.(*Store).getLatestCursor(0xc0003adce0, {0xe980a8, 0xc000657530}, {0x1427e88, 0x474a29, 0xc90b20})
16:05:59    server      /home/ben/Programming/exo/internal/eventd/sqlite/store.go:218 +0x22b
16:05:59    server github.com/deref/exo/internal/eventd/sqlite.(*Store).GetEvents(0xc0003adce0, {0xe980a8, 0xc000657530}, 0xc0002c5080)
16:05:59    server      /home/ben/Programming/exo/internal/eventd/sqlite/store.go:154 +0x185
16:05:59    server github.com/deref/exo/internal/core/server.(*Workspace).GetEvents(0xcde420, {0xe980a8, 0xc000657530}, 0xc0002c5040)
16:05:59    server      /home/ben/Programming/exo/internal/core/server/workspace.go:745 +0x2bb
16:05:59    server reflect.Value.call({0xc891a0, 0xc00040e768, 0xc00063b198}, {0xd6e4f3, 0x4}, {0xc0007c77f0, 0x2, 0x721e3a})
16:05:59    server      /usr/lib/go/src/reflect/value.go:543 +0x814
16:05:59    server reflect.Value.Call({0xc891a0, 0xc00040e768, 0xc39480}, {0xc0007c77f0, 0x2, 0x2})
16:05:59    server      /usr/lib/go/src/reflect/value.go:339 +0xc5
16:05:59    server github.com/deref/exo/internal/josh/server.(*MethodHandler).ServeHTTP(0xc00000f9c8, {0xe8f070, 0xc0006fb640}, 0xc0003fb300)
16:05:59    server      /home/ben/Programming/exo/internal/josh/server/methods.go:65 +0x593
16:05:59    server github.com/deref/exo/internal/core/server.BuildRootMux.func1.1({0xe8f070, 0xc0006fb640}, 0xc0003fb300)
16:05:59    server      /home/ben/Programming/exo/internal/core/server/handler.go:50 +0x208
16:05:59    server net/http.HandlerFunc.ServeHTTP(0x7fbd1c9055b8, {0xe8f070, 0xc0006fb640}, 0xc000657530)
16:05:59    server      /usr/lib/go/src/net/http/server.go:2046 +0x2f
16:05:59    server net/http.(*ServeMux).ServeHTTP(0xc000100c00, {0xe8f070, 0xc0006fb640}, 0xc0003fb300)
16:05:59    server      /usr/lib/go/src/net/http/server.go:2424 +0x149
16:05:59    server github.com/deref/exo/internal/util/httputil.(*HostAllowListHandler).ServeHTTP(0xc0003fe3c0, {0xe8f070, 0xc0006fb640}, 0xc0003fb300)
16:05:59    server      /home/ben/Programming/exo/internal/util/httputil/hostallowhandler.go:20 +0x176
16:05:59    server github.com/deref/exo/internal/util/httputil.HandlerWithContext.func1({0xe906c0, 0xc00022e700}, 0xc0003fb200)
16:05:59    server      /home/ben/Programming/exo/internal/util/httputil/context.go:25 +0x477
16:05:59    server net/http.HandlerFunc.ServeHTTP(0xc000150520, {0xe906c0, 0xc00022e700}, 0x0)
16:05:59    server      /usr/lib/go/src/net/http/server.go:2046 +0x2f
16:05:59    server net/http.serverHandler.ServeHTTP({0xe8e188}, {0xe906c0, 0xc00022e700}, 0xc0003fb200)
16:05:59    server      /usr/lib/go/src/net/http/server.go:2878 +0x43b
16:05:59    server net/http.(*conn).serve(0xc0004fc500, {0xe980a8, 0xc00041c5d0})
16:05:59    server      /usr/lib/go/src/net/http/server.go:1929 +0xb08
16:05:59    server created by net/http.(*Server).Serve
16:05:59    server      /usr/lib/go/src/net/http/server.go:3033 +0x4e8
```