### PR TITLE
Add noDaemon config.

### DIFF
--- a/.dev/config.toml
+++ b/.dev/config.toml
@@ -1,4 +1,5 @@
 httpPort = 4001
+noDaemon = true
 
 [client]
 url = "http://localhost:4001"

--- a/cmd/exo/daemon.go
+++ b/cmd/exo/daemon.go
@@ -30,6 +30,9 @@ Since most commands implicitly start the exo daemon, users generally do not
 have to invoke this themselves.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if cfg.NoDaemon {
+			cmdutil.Fatalf("daemon disabled by config")
+		}
 		ensureDaemon()
 		return nil
 	},
@@ -52,6 +55,9 @@ var runState struct {
 func checkOrEnsureServer() {
 	if checkHealthy() {
 		return
+	}
+	if cfg.NoDaemon {
+		cmdutil.Fatalf("daemon at %q is not healthy\ndeamonization disabled by config", effectiveServerURL())
 	}
 	if cfg.Client.URL == "" {
 		ensureDaemon()

--- a/cmd/exo/exit.go
+++ b/cmd/exo/exit.go
@@ -16,6 +16,9 @@ var exitCmd = &cobra.Command{
 	Long:  `Stop the exo daemon process.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if cfg.NoDaemon {
+			cmdutil.Fatalf("daemon disabled by config")
+		}
 		ctx := newContext()
 		checkOrEnsureServer()
 		cl := newClient()

--- a/cmd/exo/run.go
+++ b/cmd/exo/run.go
@@ -31,8 +31,8 @@ See 'exo help apply' for details on the manifest arguments.
 If a workspace does not exist, one will be created in the current directory.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		checkOrEnsureServer()
 		ctx := newContext()
-		ensureDaemon()
 		cl := newClient()
 		kernel := cl.Kernel()
 		logger := logging.CurrentLogger(ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	TokensFile   string
 
 	HTTPPort uint `toml:"httpPort"`
+	NoDaemon bool `toml:"noDaemon"`
 
 	Client    ClientConfig
 	GUI       GUIConfig `toml:"gui"`


### PR DESCRIPTION
This is largely in service of error prevention when using dexo.

I made the error of using `dexo daemon` or `dexo exit` a few times, but the server is actually expected to be running under the production `exo`'s supervision. This change presents some sensible error messages when in this mode, so that I don't screw up and to force me to dogfood exo itself more while working on exo.