### PR TITLE
Add dynamic `Icon` component

### DIFF
--- a/gui/src/components/CheckboxButton.svelte
+++ b/gui/src/components/CheckboxButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import CheckSVG from './mono/CheckSVG.svelte';
+  import Icon from './Icon.svelte';
 
   export let active: boolean = false;
   export let tooltip: string = '';
@@ -12,7 +12,7 @@
 >
   {#if active}
     <div>
-      <CheckSVG />
+      <Icon glyph="Check" />
     </div>
   {/if}
 </button>

--- a/gui/src/components/DirectoryBrowser.svelte
+++ b/gui/src/components/DirectoryBrowser.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { ReadDirResult } from '../lib/api';
-  import HomeSVG from './mono/HomeSVG.svelte';
-  import LeftUpSVG from './mono/LeftUpSVG.svelte';
+  import Icon from './Icon.svelte';
   import Textbox from './Textbox.svelte';
 
   export let dir: ReadDirResult;
@@ -16,7 +15,7 @@
     on:click={() => handleClick(String(dir.parent?.path))}
     disabled={dir.parent === null}
   >
-    <LeftUpSVG />
+    <Icon glyph="LeftUp" />
   </button>
 
   <button
@@ -24,7 +23,7 @@
     on:click={() => handleClick(homePath)}
     disabled={dir.directory.path === homePath}
   >
-    <HomeSVG />
+    <Icon glyph="Home" />
   </button>
 
   <Textbox

--- a/gui/src/components/ErrorLabel.svelte
+++ b/gui/src/components/ErrorLabel.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import WarningSVG from './mono/WarningSVG.svelte';
+  import Icon from './Icon.svelte';
 
   export let value: unknown = null;
 </script>
 
 {#if value !== null}
   <div>
-    <WarningSVG />
+    <Icon glyph="Warning" />
     <span>
       {#if value instanceof Error}
         {value.message}

--- a/gui/src/components/Icon.svelte
+++ b/gui/src/components/Icon.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  // Note, these are internal named SVG icons. Dynamic SVGs should be handled separately.
+
+  import AddSVG from './mono/AddSVG.svelte';
+  import BackSVG from './mono/BackSVG.svelte';
+  import CheckSVG from './mono/CheckSVG.svelte';
+  import DeleteSVG from './mono/DeleteSVG.svelte';
+  import DetailsSVG from './mono/DetailsSVG.svelte';
+  import DockerSVG from './mono/DockerSVG.svelte';
+  import EllipsisSVG from './mono/EllipsisSVG.svelte';
+  import FeedbackSVG from './mono/FeedbackSVG.svelte';
+  import HomeSVG from './mono/HomeSVG.svelte';
+  import LayersSVG from './mono/LayersSVG.svelte';
+  import LeftUpSVG from './mono/LeftUpSVG.svelte';
+  import LogsSVG from './mono/LogsSVG.svelte';
+  import NetworkingSVG from './mono/NetworkingSVG.svelte';
+  import PauseSVG from './mono/PauseSVG.svelte';
+  import PlaySVG from './mono/PlaySVG.svelte';
+  import PreferencesSVG from './mono/PreferencesSVG.svelte';
+  import ResetSVG from './mono/ResetSVG.svelte';
+  import StorageSVG from './mono/StorageSVG.svelte';
+  import VariableSVG from './mono/VariableSVG.svelte';
+  import WarningSVG from './mono/WarningSVG.svelte';
+
+  export let glyph: string;
+</script>
+
+{#if glyph === 'Add'}
+  <AddSVG />
+{:else if glyph === 'Back'}
+  <BackSVG />
+{:else if glyph === 'Check'}
+  <CheckSVG />
+{:else if glyph === 'Delete'}
+  <DeleteSVG />
+{:else if glyph === 'Details'}
+  <DetailsSVG />
+{:else if glyph === 'Docker'}
+  <DockerSVG />
+{:else if glyph === 'Ellipsis'}
+  <EllipsisSVG />
+{:else if glyph === 'Feedback'}
+  <FeedbackSVG />
+{:else if glyph === 'Home'}
+  <HomeSVG />
+{:else if glyph === 'Layers'}
+  <LayersSVG />
+{:else if glyph === 'LeftUp'}
+  <LeftUpSVG />
+{:else if glyph === 'Logs'}
+  <LogsSVG />
+{:else if glyph === 'Networking'}
+  <NetworkingSVG />
+{:else if glyph === 'Pause'}
+  <PauseSVG />
+{:else if glyph === 'Play'}
+  <PlaySVG />
+{:else if glyph === 'Preferences'}
+  <PreferencesSVG />
+{:else if glyph === 'Reset'}
+  <ResetSVG />
+{:else if glyph === 'Storage'}
+  <StorageSVG />
+{:else if glyph === 'Variable'}
+  <VariableSVG />
+{:else if glyph === 'Warning'}
+  <WarningSVG />
+{:else}
+  <LayersSVG />
+{/if}

--- a/gui/src/components/IconButton.svelte
+++ b/gui/src/components/IconButton.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
+
   export let tooltip: string | undefined = undefined;
+  export let glyph: string;
 </script>
 
 <button on:click title={tooltip}>
-  <slot />
+  <Icon {glyph} />
 </button>
 
 <style>

--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import VersionInfo from './VersionInfo.svelte';
   import NavbarRoute from './nav/NavbarRoute.svelte';
   import NavbarButton from './nav/NavbarButton.svelte';
-  import FeedbackSVG from './mono/FeedbackSVG.svelte';
-  import PreferencesSVG from './mono/PreferencesSVG.svelte';
   import { theme, themeOptions } from '../lib/theme';
 
   $: {
@@ -29,7 +28,7 @@
     </div>
     <footer>
       <NavbarRoute title="Preferences" href="#/preferences">
-        <PreferencesSVG />
+        <Icon glyph="Preferences" />
       </NavbarRoute>
       <NavbarButton
         title="Give feedback on GitHub"
@@ -37,7 +36,7 @@
           window.location.href = 'https://github.com/deref/exo/discussions';
         }}
       >
-        <FeedbackSVG />
+        <Icon glyph="Feedback" />
       </NavbarButton>
       <VersionInfo />
     </footer>

--- a/gui/src/components/Panel.svelte
+++ b/gui/src/components/Panel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import IconButton from './IconButton.svelte';
-  import BackSVG from './mono/BackSVG.svelte';
   import * as router from 'svelte-spa-router';
 
   export let title: string = '';
@@ -17,7 +17,7 @@
             router.push(backRoute ?? '');
           }}
         >
-          <BackSVG />
+          <Icon glyph="Back" />
         </IconButton>
       {/if}
 

--- a/gui/src/components/Panel.svelte
+++ b/gui/src/components/Panel.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Icon from './Icon.svelte';
   import IconButton from './IconButton.svelte';
   import * as router from 'svelte-spa-router';
 

--- a/gui/src/components/Panel.svelte
+++ b/gui/src/components/Panel.svelte
@@ -12,13 +12,12 @@
     <div class="header-title">
       {#if backRoute}
         <IconButton
+          glyph="Back"
           tooltip="Go back"
           on:click={() => {
             router.push(backRoute ?? '');
           }}
-        >
-          <Icon glyph="Back" />
-        </IconButton>
+        />
       {/if}
 
       {#if title}

--- a/gui/src/components/ProcessList.svelte
+++ b/gui/src/components/ProcessList.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import Panel from './Panel.svelte';
   import IconButton from './IconButton.svelte';
   import ProcfileChecker from './processes/ProcfileChecker.svelte';
   import ProcessListTable from './processes/ProcessListTable.svelte';
-  import AddSVG from './mono/AddSVG.svelte';
-  import DetailsSVG from './mono/DetailsSVG.svelte';
-  import EllipsisSVG from './mono/EllipsisSVG.svelte';
   import { onDestroy, onMount } from 'svelte';
   import type { RequestLifecycle, WorkspaceApi } from '../lib/api';
   import type { ProcessDescription } from '../lib/process/types';
@@ -71,7 +69,7 @@
       <span>Logs</span>
       <div class="menu">
         <IconButton tooltip="Workspace actions..." on:click={() => {}}>
-          <EllipsisSVG />
+          <Icon glyph="Ellipsis" />
         </IconButton>
 
         <div class="dropdown">
@@ -83,7 +81,7 @@
               );
             }}
           >
-            <DetailsSVG />
+            <Icon glyph="Details" />
             View details
           </button>
           <button
@@ -93,7 +91,7 @@
               );
             }}
           >
-            <AddSVG />
+            <Icon glyph="Add" />
             Add component
           </button>
         </div>
@@ -108,7 +106,7 @@
           );
         }}
       >
-        <AddSVG /> Add component
+        <Icon glyph="Add" /> Add component
       </button>
       <RemoteData data={processList} let:data let:error>
         <div slot="success">

--- a/gui/src/components/ProcessList.svelte
+++ b/gui/src/components/ProcessList.svelte
@@ -68,9 +68,11 @@
     <div class="actions" slot="actions">
       <span>Logs</span>
       <div class="menu">
-        <IconButton tooltip="Workspace actions..." on:click={() => {}}>
-          <Icon glyph="Ellipsis" />
-        </IconButton>
+        <IconButton
+          glyph="Ellipsis"
+          tooltip="Workspace actions..."
+          on:click={() => {}}
+        />
 
         <div class="dropdown">
           <span>{displayName}</span>

--- a/gui/src/components/VersionInfo.svelte
+++ b/gui/src/components/VersionInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import Button from './Button.svelte';
   import Spinner from './Spinner.svelte';
-  import EllipsisSVG from './mono/EllipsisSVG.svelte';
   import NavbarButton from './nav/NavbarButton.svelte';
   import { onDestroy } from 'svelte';
   import { api } from '../lib/api';
@@ -44,7 +44,7 @@
     {#if latestVersion !== null}
       <div class="upgrade-available" />
     {:else}
-      <EllipsisSVG />
+      <Icon glyph="Ellipsis" />
     {/if}
   </NavbarButton>
   <div class="dropdown version">

--- a/gui/src/components/WorkspaceNav.svelte
+++ b/gui/src/components/WorkspaceNav.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import NavbarRoute from './nav/NavbarRoute.svelte';
-  import HomeSVG from './mono/HomeSVG.svelte';
-  import LayersSVG from './mono/LayersSVG.svelte';
-  import StorageSVG from './mono/StorageSVG.svelte';
-  import VariableSVG from './mono/VariableSVG.svelte';
-  import NetworkingSVG from './mono/NetworkingSVG.svelte';
 
   export let workspaceId: string;
   export let active: string;
@@ -12,7 +8,7 @@
 
 <aside>
   <NavbarRoute title="Dashboard" href={`#/workspaces/${workspaceId}`} {active}>
-    <HomeSVG />
+    <Icon glyph="Home" />
   </NavbarRoute>
 
   <NavbarRoute
@@ -20,7 +16,7 @@
     href={`#/workspaces/${workspaceId}/components`}
     {active}
   >
-    <LayersSVG />
+    <Icon glyph="Layers" />
   </NavbarRoute>
 
   <NavbarRoute
@@ -28,7 +24,7 @@
     href={`#/workspaces/${workspaceId}/variables`}
     {active}
   >
-    <VariableSVG />
+    <Icon glyph="Variable" />
   </NavbarRoute>
 
   <NavbarRoute
@@ -36,7 +32,7 @@
     href={`#/workspaces/${workspaceId}/storage`}
     {active}
   >
-    <StorageSVG />
+    <Icon glyph="Storage" />
   </NavbarRoute>
 
   <NavbarRoute
@@ -44,6 +40,6 @@
     href={`#/workspaces/${workspaceId}/networking`}
     {active}
   >
-    <NetworkingSVG />
+    <Icon glyph="Networking" />
   </NavbarRoute>
 </aside>

--- a/gui/src/components/WorkspaceNav.svelte
+++ b/gui/src/components/WorkspaceNav.svelte
@@ -4,42 +4,40 @@
 
   export let workspaceId: string;
   export let active: string;
+
+  const routes = [
+    {
+      title: 'Dashboard',
+      href: `#/workspaces/${workspaceId}`,
+      glyph: 'Home',
+    },
+    {
+      title: 'Components',
+      href: `#/workspaces/${workspaceId}/components`,
+      glyph: 'Layers',
+    },
+    {
+      title: 'Variables',
+      href: `#/workspaces/${workspaceId}/variables`,
+      glyph: 'Variable',
+    },
+    {
+      title: 'Storage',
+      href: `#/workspaces/${workspaceId}/storage`,
+      glyph: 'Storage',
+    },
+    {
+      title: 'Networking',
+      href: `#/workspaces/${workspaceId}/networking`,
+      glyph: 'Networking',
+    },
+  ];
 </script>
 
 <aside>
-  <NavbarRoute title="Dashboard" href={`#/workspaces/${workspaceId}`} {active}>
-    <Icon glyph="Home" />
-  </NavbarRoute>
-
-  <NavbarRoute
-    title="Components"
-    href={`#/workspaces/${workspaceId}/components`}
-    {active}
-  >
-    <Icon glyph="Layers" />
-  </NavbarRoute>
-
-  <NavbarRoute
-    title="Variables"
-    href={`#/workspaces/${workspaceId}/variables`}
-    {active}
-  >
-    <Icon glyph="Variable" />
-  </NavbarRoute>
-
-  <NavbarRoute
-    title="Storage"
-    href={`#/workspaces/${workspaceId}/storage`}
-    {active}
-  >
-    <Icon glyph="Storage" />
-  </NavbarRoute>
-
-  <NavbarRoute
-    title="Networking"
-    href={`#/workspaces/${workspaceId}/networking`}
-    {active}
-  >
-    <Icon glyph="Networking" />
-  </NavbarRoute>
+  {#each routes as route}
+    <NavbarRoute title={route.title} href={route.href} {active}>
+      <Icon glyph={route.glyph} />
+    </NavbarRoute>
+  {/each}
 </aside>

--- a/gui/src/components/processes/ProcessListTable.svelte
+++ b/gui/src/components/processes/ProcessListTable.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
+  import Icon from '../Icon.svelte';
   import IconButton from '../IconButton.svelte';
   import CheckboxButton from '../CheckboxButton.svelte';
   import ProcessRunControls from './ProcessRunControls.svelte';
-  import LogsSVG from '../mono/LogsSVG.svelte';
-  import DeleteSVG from '../mono/DeleteSVG.svelte';
-  import DetailsSVG from '../mono/DetailsSVG.svelte';
-  import EllipsisSVG from '../mono/EllipsisSVG.svelte';
   import * as router from 'svelte-spa-router';
   import {
     startProcess,
@@ -81,7 +78,7 @@
 
     <div class="actions">
       <IconButton>
-        <EllipsisSVG />
+        <Icon glyph="Ellipsis" />
       </IconButton>
       <div class="dropdown">
         <span>{name}</span>
@@ -94,7 +91,7 @@
             );
           }}
         >
-          <DetailsSVG />
+          <Icon glyph="Details" />
           View details
         </button>
         <button
@@ -102,7 +99,7 @@
             setProcLogs(id, $visibleLogsStore.has(id) ? false : true);
           }}
         >
-          <LogsSVG />
+          <Icon glyph="Logs" />
           Toggle logs visibility
         </button>
         <button
@@ -111,7 +108,7 @@
             setProcLogs(id, false);
           }}
         >
-          <DeleteSVG />
+          <Icon glyph="Delete" />
           Remove from <b>exo</b>
         </button>
       </div>

--- a/gui/src/components/processes/ProcessListTable.svelte
+++ b/gui/src/components/processes/ProcessListTable.svelte
@@ -77,9 +77,7 @@
     </div>
 
     <div class="actions">
-      <IconButton>
-        <Icon glyph="Ellipsis" />
-      </IconButton>
+      <IconButton glyph="Ellipsis" />
       <div class="dropdown">
         <span>{name}</span>
         <button

--- a/gui/src/components/processes/ProcessRunControls.svelte
+++ b/gui/src/components/processes/ProcessRunControls.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  import IconButton from '../IconButton.svelte';
+  import Icon from '../Icon.svelte';
   import Spinner from '../Spinner.svelte';
-  import PlaySVG from '../mono/PlaySVG.svelte';
-  import PauseSVG from '../mono/PauseSVG.svelte';
+  import IconButton from '../IconButton.svelte';
 
   export let setProcRun: (id: string, run: boolean) => void;
   export let statusPending: Set<string>;
@@ -17,14 +16,14 @@
     <div class="running unhover-only" />
     <div class="control hover-only">
       <IconButton tooltip="Stop process" on:click={() => setProcRun(id, false)}>
-        <PauseSVG />
+        <Icon glyph="Pause" />
       </IconButton>
     </div>
   {:else}
     <div class="stopped unhover-only" />
     <div class="control hover-only">
       <IconButton tooltip="Run process" on:click={() => setProcRun(id, true)}>
-        <PlaySVG />
+        <Icon glyph="Play" />
       </IconButton>
     </div>
   {/if}

--- a/gui/src/components/processes/ProcessRunControls.svelte
+++ b/gui/src/components/processes/ProcessRunControls.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Icon from '../Icon.svelte';
   import Spinner from '../Spinner.svelte';
   import IconButton from '../IconButton.svelte';
 

--- a/gui/src/components/processes/ProcessRunControls.svelte
+++ b/gui/src/components/processes/ProcessRunControls.svelte
@@ -15,16 +15,20 @@
   {:else if running}
     <div class="running unhover-only" />
     <div class="control hover-only">
-      <IconButton tooltip="Stop process" on:click={() => setProcRun(id, false)}>
-        <Icon glyph="Pause" />
-      </IconButton>
+      <IconButton
+        glyph="Pause"
+        tooltip="Stop process"
+        on:click={() => setProcRun(id, false)}
+      />
     </div>
   {:else}
     <div class="stopped unhover-only" />
     <div class="control hover-only">
-      <IconButton tooltip="Run process" on:click={() => setProcRun(id, true)}>
-        <Icon glyph="Play" />
-      </IconButton>
+      <IconButton
+        glyph="Play"
+        tooltip="Run process"
+        on:click={() => setProcRun(id, true)}
+      />
     </div>
   {/if}
 </div>

--- a/gui/src/pages/NewDockerComponent.svelte
+++ b/gui/src/pages/NewDockerComponent.svelte
@@ -5,6 +5,7 @@
 </script>
 
 <script lang="ts">
+  import Icon from '../components/Icon.svelte';
   import Layout from '../components/Layout.svelte';
   import Textbox from '../components/Textbox.svelte';
   import EditAs from '../components/form/EditAs.svelte';
@@ -12,7 +13,6 @@
   import TextEditor from '../components/TextEditor.svelte';
   import SubmitButton from '../components/form/SubmitButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
-  import DockerSVG from '../components/mono/DockerSVG.svelte';
   import { api, isClientError } from '../lib/api';
   import { setLogVisibility } from '../lib/logs/visible-logs';
   import * as router from 'svelte-spa-router';
@@ -52,7 +52,7 @@
     title={`New ${displayType}`}
     backRoute={workspaceNewComponentRoute}
   >
-    <h1><DockerSVG /> New {displayType}</h1>
+    <h1><Icon glyph="Docker" /> New {displayType}</h1>
     <form
       on:submit|preventDefault={async () => {
         try {

--- a/gui/src/pages/NewProcess.svelte
+++ b/gui/src/pages/NewProcess.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '../components/Icon.svelte';
   import Layout from '../components/Layout.svelte';
   import Textbox from '../components/Textbox.svelte';
   import EditAs from '../components/form/EditAs.svelte';
@@ -10,7 +11,6 @@
   import SubmitButton from '../components/form/SubmitButton.svelte';
   import EnvironmentInput from '../components/EnvironmentInput.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
-  import LayersSVG from '../components/mono/LayersSVG.svelte';
   import { api, isClientError } from '../lib/api';
   import * as router from 'svelte-spa-router';
   import { parseScript, generateScript } from '../lib/process/script';
@@ -80,7 +80,7 @@ my-app --port 4000
 <Layout>
   <WorkspaceNav {workspaceId} active="Dashboard" slot="navbar" />
   <CenterFormPanel title="New Process" backRoute={workspaceNewComponentRoute}>
-    <h1><LayersSVG /> New Process</h1>
+    <h1><Icon glyph="Layers" /> New Process</h1>
     <form
       on:submit|preventDefault={async () => {
         updateFields();

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -14,9 +14,11 @@
 <Layout>
   <CenterFormPanel title="Preferences">
     <div slot="actions">
-      <IconButton tooltip="Reset to defaults" on:click={resetAllPreferences}>
-        <Icon glyph="Reset" />
-      </IconButton>
+      <IconButton
+        glyph="Reset"
+        tooltip="Reset to defaults"
+        on:click={resetAllPreferences}
+      />
     </div>
     <div>
       <div class="group">

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
+  import Icon from '../components/Icon.svelte';
   import Button from '../components/Button.svelte';
   import Layout from '../components/Layout.svelte';
   import IconButton from '../components/IconButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
-  import PreferencesSectionsConfig from '../components/form/PreferencesSectionsConfig.svelte';
-  import ResetSVG from '../components/mono/ResetSVG.svelte';
   import { theme } from '../lib/theme';
 
   const resetAllPreferences = () => {
@@ -16,7 +15,7 @@
   <CenterFormPanel title="Preferences">
     <div slot="actions">
       <IconButton tooltip="Reset to defaults" on:click={resetAllPreferences}>
-        <ResetSVG />
+        <Icon glyph="Reset" />
       </IconButton>
     </div>
     <div>
@@ -59,7 +58,6 @@
           </Button>
         </div>
       </div>
-      <!-- <PreferencesSectionsConfig /> -->
     </div>
   </CenterFormPanel>
 </Layout>

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Icon from '../components/Icon.svelte';
   import Button from '../components/Button.svelte';
   import Layout from '../components/Layout.svelte';
   import IconButton from '../components/IconButton.svelte';

--- a/gui/src/pages/WorkspaceNewComponent.svelte
+++ b/gui/src/pages/WorkspaceNewComponent.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import Icon from '../components/Icon.svelte';
   import Layout from '../components/Layout.svelte';
   import WorkspaceNav from '../components/WorkspaceNav.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
-  import LayersSVG from '../components/mono/LayersSVG.svelte';
-  import DockerSVG from '../components/mono/DockerSVG.svelte';
   import * as router from 'svelte-spa-router';
 
   export let params = { workspace: '' };
@@ -25,7 +24,7 @@
           );
         }}
       >
-        <LayersSVG />
+        <Icon glyph="Layers" />
         <b>Process</b>
       </button>
 
@@ -42,7 +41,7 @@
           );
         }}
       >
-        <DockerSVG />
+        <Icon glyph="Docker" />
         <b>Container</b>
       </button>
 
@@ -53,7 +52,7 @@
           );
         }}
       >
-        <DockerSVG />
+        <Icon glyph="Docker" />
         <b>Volume</b>
       </button>
 
@@ -64,7 +63,7 @@
           );
         }}
       >
-        <DockerSVG />
+        <Icon glyph="Docker" />
         <b>Network</b>
       </button>
     </section>

--- a/gui/src/pages/WorkspaceNewComponent.svelte
+++ b/gui/src/pages/WorkspaceNewComponent.svelte
@@ -9,66 +9,67 @@
 
   const workspaceId = params.workspace;
   const workspaceRoute = `/workspaces/${encodeURIComponent(workspaceId)}`;
+
+  const categories = [
+    {
+      componentTypes: [
+        // Generic components...
+        {
+          displayName: 'Process',
+          name: 'process',
+          glyph: 'Layers',
+        },
+      ],
+    },
+    {
+      title: 'Docker',
+      componentTypes: [
+        // Docker components...
+        {
+          displayName: 'Container',
+          name: 'container',
+          glyph: 'Docker',
+        },
+        {
+          displayName: 'Volume',
+          name: 'volume',
+          glyph: 'Docker',
+        },
+        {
+          displayName: 'Network',
+          name: 'network',
+          glyph: 'Docker',
+        },
+      ],
+    },
+    // Cloud services, databases, etc...
+  ];
 </script>
 
 <Layout>
   <WorkspaceNav {workspaceId} active="Dashboard" slot="navbar" />
   <CenterFormPanel title="New component" backRoute={workspaceRoute}>
-    <section>
-      <!-- Generic components, no heading. -->
-
-      <button
-        on:click={() => {
-          router.push(
-            `/workspaces/${encodeURIComponent(workspaceId)}/new-process`,
-          );
-        }}
-      >
-        <Icon glyph="Layers" />
-        <b>Process</b>
-      </button>
-
-      <!-- Timer, External Link, etc. -->
-    </section>
-
-    <section>
-      <h2>Docker</h2>
-
-      <button
-        on:click={() => {
-          router.push(
-            `/workspaces/${encodeURIComponent(workspaceId)}/new-container`,
-          );
-        }}
-      >
-        <Icon glyph="Docker" />
-        <b>Container</b>
-      </button>
-
-      <button
-        on:click={() => {
-          router.push(
-            `/workspaces/${encodeURIComponent(workspaceId)}/new-volume`,
-          );
-        }}
-      >
-        <Icon glyph="Docker" />
-        <b>Volume</b>
-      </button>
-
-      <button
-        on:click={() => {
-          router.push(
-            `/workspaces/${encodeURIComponent(workspaceId)}/new-network`,
-          );
-        }}
-      >
-        <Icon glyph="Docker" />
-        <b>Network</b>
-      </button>
-    </section>
-
-    <!-- Databases, Apps, cloud services, etc. -->
+    {#each categories as category}
+      <section>
+        {#if category.title}
+          <h2>{category.title}</h2>
+        {/if}
+        {#each category.componentTypes as componentType}
+          <button
+            on:click={() => {
+              router.push(
+                `${workspaceRoute}/new-${encodeURIComponent(
+                  componentType.name,
+                )}`,
+              );
+            }}
+          >
+            <Icon glyph={componentType.glyph} />
+            <b>{componentType.displayName}</b>
+          </button>
+        {/each}
+      </section>
+    {/each}
   </CenterFormPanel>
 </Layout>
 
@@ -85,6 +86,7 @@
     padding: 16px 32px 16px 24px;
     position: relative;
     display: grid;
+    width: 100%;
     grid-template-columns: max-content max-content max-content;
     align-items: center;
     gap: 12px;


### PR DESCRIPTION
Adds a single `Icon` component with named `glyph` attribute so icons can be dynamic in data

For example, instead of

```
import IconASVG from "./mono/IconASVG.svelte";
import IconBSVG from "./mono/IconBSVG.svelte";
import IconCSVG from "./mono/IconCSVG.svelte";
...
<IconASVG />
<IconBSVG />
<IconCSVG />
```

you write

```
import Icon from "./Icon.svelte"
...
<Icon glyph="IconA" />
<Icon glyph="IconB" />
<Icon glyph="IconC" />
```

This means we can finally get the best of both worlds by having Svelte component SVG icons which can be dynamically looped over and chosen with data.