### PR TITLE
Event tags

### DIFF
--- a/cmd/exo/new_process.go
+++ b/cmd/exo/new_process.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/deref/exo/internal/core/api"
 	"github.com/deref/exo/internal/providers/unix/components/process"
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/exo/state.go
+++ b/cmd/exo/state.go
@@ -6,8 +6,9 @@ import (
 	"os"
 
 	"github.com/deref/exo/internal/core/api"
-	"github.com/deref/exo/internal/util/jsonutil"
+	exojsonutil "github.com/deref/exo/internal/util/jsonutil"
 	"github.com/deref/exo/internal/util/term"
+	"github.com/deref/util-go/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,7 @@ var stateGetCmd = &cobra.Command{
 			return err
 		}
 
-		return jsonutil.PrettyPrintJSONString(os.Stdout, output.State)
+		return exojsonutil.PrettyPrintJSONString(os.Stdout, output.State)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/containerd v1.5.4 // indirect
 	github.com/deref/inflect-go v0.0.0-20210922215725-28c4e8c11b16
 	github.com/deref/pier v0.0.0-20210620044641-0f71544154e7
+	github.com/deref/util-go v0.0.0-20210922232622-f6f9aa9d157d // indirect
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/deref/inflect-go v0.0.0-20210922215725-28c4e8c11b16 h1:DjJSMfCxR6g9Ay
 github.com/deref/inflect-go v0.0.0-20210922215725-28c4e8c11b16/go.mod h1:P7w/BgRpR0XR6ZuQq/5BX8KVAU3ptKvbQNwoqfVtrMw=
 github.com/deref/pier v0.0.0-20210620044641-0f71544154e7 h1:5hgmmF4pOm02j9TgRXIodXBa17dYZgKAazljGdo1LNE=
 github.com/deref/pier v0.0.0-20210620044641-0f71544154e7/go.mod h1:WI1OJe9dqbCxI7pNQnil+WrX7RlDqMiM9GjRWFRRfZI=
+github.com/deref/util-go v0.0.0-20210922232622-f6f9aa9d157d h1:FBk6FpOdBCir8+g6Fbo7kzRJhkOrX6lrruGc38w5d8k=
+github.com/deref/util-go v0.0.0-20210922232622-f6f9aa9d157d/go.mod h1:qWY9JpUbfLtuKnXHapBYewRn5oCQuYKqpzK2PHyDtlY=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -480,10 +480,11 @@ type StreamDescription struct {
 }
 
 type Event struct {
-	ID        string `json:"id"`
-	Stream    string `json:"stream"`
-	Timestamp string `json:"timestamp"`
-	Message   string `json:"message"`
+	ID        string            `json:"id"`
+	Stream    string            `json:"stream"`
+	Timestamp string            `json:"timestamp"`
+	Message   string            `json:"message"`
+	Tags      map[string]string `json:"tags"`
 }
 
 type ProcessDescription struct {

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -266,6 +266,7 @@ struct "event" {
   field "stream" "string" {}
   field "timestamp" "string" {}
   field "message" "string" {}
+  field "tags" "map[string]string" {}
 }
 
 struct "process-description" {

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -700,13 +700,13 @@ func (ws *Workspace) DescribeStreams(ctx context.Context, input *api.DescribeStr
 
 	// Decorate output with information from the event store.
 	eventStore := log.CurrentEventStore(ctx)
-	collectorLogs, err := eventStore.DescribeStreams(ctx, &eventd.DescribeStreamsInput{
+	storeLogs, err := eventStore.DescribeStreams(ctx, &eventd.DescribeStreamsInput{
 		Names: logStreams,
 	})
 	if err != nil {
 		return nil, err
 	}
-	for _, stream := range collectorLogs.Streams {
+	for _, stream := range storeLogs.Streams {
 		groupIndex, ok := streamToGroup[stream.Name]
 		if !ok {
 			continue
@@ -756,7 +756,7 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 	}
 
 	eventStore := log.CurrentEventStore(ctx)
-	collectorOutput, err := eventStore.GetEvents(ctx, &eventd.GetEventsInput{
+	storeOutput, err := eventStore.GetEvents(ctx, &eventd.GetEventsInput{
 		Streams:   logStreams,
 		Cursor:    input.Cursor,
 		FilterStr: input.FilterStr,
@@ -767,16 +767,16 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 		return nil, err
 	}
 	output := api.GetEventsOutput{
-		Items:      make([]api.Event, len(collectorOutput.Items)),
-		PrevCursor: collectorOutput.PrevCursor,
-		NextCursor: collectorOutput.NextCursor,
+		Items:      make([]api.Event, len(storeOutput.Items)),
+		PrevCursor: storeOutput.PrevCursor,
+		NextCursor: storeOutput.NextCursor,
 	}
-	for i, collectorEvent := range collectorOutput.Items {
+	for i, storeEvent := range storeOutput.Items {
 		output.Items[i] = api.Event{
-			ID:        collectorEvent.ID,
-			Stream:    collectorEvent.Stream,
-			Timestamp: collectorEvent.Timestamp,
-			Message:   collectorEvent.Message,
+			ID:        storeEvent.ID,
+			Stream:    storeEvent.Stream,
+			Timestamp: storeEvent.Timestamp,
+			Message:   storeEvent.Message,
 		}
 	}
 	return &output, nil

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -777,6 +777,7 @@ func (ws *Workspace) GetEvents(ctx context.Context, input *api.GetEventsInput) (
 			Stream:    storeEvent.Stream,
 			Timestamp: storeEvent.Timestamp,
 			Message:   storeEvent.Message,
+			Tags:      storeEvent.Tags,
 		}
 	}
 	return &output, nil

--- a/internal/eventd/api/store.go
+++ b/internal/eventd/api/store.go
@@ -35,9 +35,10 @@ type DescribeStreamsOutput struct {
 }
 
 type AddEventInput struct {
-	Stream    string `json:"stream"`
-	Timestamp string `json:"timestamp"`
-	Message   string `json:"message"`
+	Stream    string            `json:"stream"`
+	Timestamp string            `json:"timestamp"`
+	Message   string            `json:"message"`
+	Tags      map[string]string `json:"tags"`
 }
 
 type AddEventOutput struct {
@@ -87,8 +88,9 @@ type StreamDescription struct {
 }
 
 type Event struct {
-	ID        string `json:"id"`
-	Stream    string `json:"stream"`
-	Timestamp string `json:"timestamp"`
-	Message   string `json:"message"`
+	ID        string            `json:"id"`
+	Stream    string            `json:"stream"`
+	Timestamp string            `json:"timestamp"`
+	Message   string            `json:"message"`
+	Tags      map[string]string `json:"tags"`
 }

--- a/internal/eventd/api/store.josh.hcl
+++ b/internal/eventd/api/store.josh.hcl
@@ -15,6 +15,7 @@ interface "store" {
     input "stream" "string" {}
     input "timestamp" "string" {}
     input "message" "string" {}
+    input "tags" "map[string]string" {}
   }
 
   method "get-events" {
@@ -47,4 +48,5 @@ struct "event" {
   field "stream" "string" {}
   field "timestamp" "string" {}
   field "message" "string" {}
+  field "tags" "map[string]string" {}
 }

--- a/internal/eventd/sqlite/migrate.go
+++ b/internal/eventd/sqlite/migrate.go
@@ -11,7 +11,8 @@ func (sto *Store) Migrate(ctx context.Context) error {
 			stream TEXT NOT NULL,
 			id TEXT NOT NULL,
 			timestamp INTEGER NOT NULL,
-			message TEXT NOT NULL
+			message TEXT NOT NULL,
+			tags TEXT NOT NULL
 		);`); err != nil {
 		return fmt.Errorf("creating event table: %w", err)
 	}

--- a/internal/exod/main.go
+++ b/internal/exod/main.go
@@ -180,7 +180,7 @@ func RunServer(ctx context.Context, flags map[string]string) {
 
 		go func() {
 			if err := syslogServer.Run(ctx); err != nil {
-				cmdutil.Fatalf("log collector error: %w", err)
+				cmdutil.Fatalf("syslog server error: %w", err)
 			}
 		}()
 

--- a/internal/manifest/procfile/convert.go
+++ b/internal/manifest/procfile/convert.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/deref/exo/internal/manifest"
 	"github.com/deref/exo/internal/providers/unix/components/process"
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 )
 
 type loader struct{}

--- a/internal/providers/core/components/log/context.go
+++ b/internal/providers/core/components/log/context.go
@@ -1,4 +1,4 @@
-// TODO: Delete this file & pass LogCollector around like state.Store.
+// TODO: Can we avoid putting the event store in to context?
 
 package log
 

--- a/internal/providers/docker/components/container/controller.go
+++ b/internal/providers/docker/components/container/controller.go
@@ -3,7 +3,7 @@ package container
 import (
 	"fmt"
 
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 	"github.com/goccy/go-yaml"
 )
 

--- a/internal/providers/docker/components/network/controller.go
+++ b/internal/providers/docker/components/network/controller.go
@@ -3,7 +3,7 @@ package network
 import (
 	"fmt"
 
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 	"github.com/goccy/go-yaml"
 )
 

--- a/internal/providers/docker/components/volume/controller.go
+++ b/internal/providers/docker/components/volume/controller.go
@@ -3,7 +3,7 @@ package volume
 import (
 	"fmt"
 
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 	"github.com/goccy/go-yaml"
 )
 

--- a/internal/providers/unix/components/process/controller.go
+++ b/internal/providers/unix/components/process/controller.go
@@ -5,7 +5,7 @@ package process
 import (
 	"fmt"
 
-	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/util-go/jsonutil"
 )
 
 func (p *Process) InitResource() error {

--- a/internal/syslogd/server.go
+++ b/internal/syslogd/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 )
 
-// Server implements a UDP-based Syslog server backed by a log collector store.
+// Server implements a UDP-based Syslog server.
 type Server struct {
 	Logger     logging.Logger
 	SyslogPort uint

--- a/internal/util/jsonutil/jsonutil.go
+++ b/internal/util/jsonutil/jsonutil.go
@@ -15,19 +15,6 @@ func UnmarshalString(s string, v interface{}) error {
 	return json.Unmarshal([]byte(s), v)
 }
 
-func MarshalString(v interface{}) (string, error) {
-	bs, err := json.Marshal(v)
-	return string(bs), err
-}
-
-func MustMarshalString(v interface{}) string {
-	s, err := MarshalString(v)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
 func UnmarshalReader(r io.Reader, v interface{}) error {
 	bs, err := ioutil.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
This adds string tags to each event. I intend to use this to combine the stdout & stderr streams in to one stream, simplifying our stream name handling logic, but preserving the provenance of log messages & opening up an extensibility point for extra metadata on events.

**NOTE: This will break if you've been on the latest main branch.** We haven't shipped the sqlite code to users yet, so here is a manual migration step that users don't need to do:

```bash
exo stop server
exo exit
sqlite3 ~/.exo/var/exo.sqlite3 'drop table event;'
sqlite3 ./.dev/var/exo.sqlite3 'drop table event;'
exo start server
```