### PR TITLE
State history

### DIFF
--- a/internal/compstate/api/store.go
+++ b/internal/compstate/api/store.go
@@ -1,0 +1,59 @@
+// Generated file. DO NOT EDIT.
+
+package api
+
+import (
+	"context"
+	"net/http"
+
+	josh "github.com/deref/exo/internal/josh/server"
+)
+
+type Store interface {
+	SetState(context.Context, *SetStateInput) (*SetStateOutput, error)
+	GetStates(context.Context, *GetStatesInput) (*GetStatesOutput, error)
+}
+
+type SetStateInput struct {
+	ComponentID string            `json:"componentId"`
+	Type        string            `json:"type"`
+	Content     string            `json:"content"`
+	Tags        map[string]string `json:"tags"`
+	Timestamp   string            `json:"timestamp"`
+}
+
+type SetStateOutput struct {
+	Version int `json:"version"`
+}
+
+type GetStatesInput struct {
+	ComponentID string `json:"componentId"`
+	// If not specified, begins history with most recent.
+	Version int `json:"version"`
+	// Limit of historical states to return per component. Defaults to 1.
+	History int `json:"history"`
+}
+
+type GetStatesOutput struct {
+
+	// With descending version numbers.
+	States []State `json:"states"`
+}
+
+func BuildStoreMux(b *josh.MuxBuilder, factory func(req *http.Request) Store) {
+	b.AddMethod("set-state", func(req *http.Request) interface{} {
+		return factory(req).SetState
+	})
+	b.AddMethod("get-states", func(req *http.Request) interface{} {
+		return factory(req).GetStates
+	})
+}
+
+type State struct {
+	ComponentID string            `json:"componentId"`
+	Version     int               `json:"version"`
+	Type        string            `json:"type"`
+	Content     string            `json:"content"`
+	Tags        map[string]string `json:"tags"`
+	Timestamp   string            `json:"timestamp"`
+}

--- a/internal/compstate/api/store.josh.hcl
+++ b/internal/compstate/api/store.josh.hcl
@@ -1,0 +1,37 @@
+interface "store" {
+  method "set-state" {
+    input "component-id" "string" {}
+    input "type" "string" {}
+    input "content" "string" {}
+    input "tags" "map[string]string" {}
+    input "timestamp" "string" {}
+    
+    output "version" "int" {}
+  }
+  
+  method "get-states" {
+    input "component-id" "string" {}
+    input "version" "int" {
+      doc = "If not specified, begins history with most recent."
+    }
+    input "history" "int" {
+      doc = "Limit of historical states to return per component. Defaults to 1."
+    }
+    
+    output "states" "[]State" {
+      doc = "With descending version numbers."
+    }
+  }
+  
+  // TODO: describe-components?
+  // TODO: garbage collection?
+}
+
+struct "state" {
+  field "component-id" "string" {}
+  field "version" "int" {}
+  field "type" "string" {}
+  field "content" "string" {}
+  field "tags" "map[string]string" {}
+  field "timestamp" "string" {}
+}

--- a/internal/compstate/client/store.go
+++ b/internal/compstate/client/store.go
@@ -1,0 +1,32 @@
+// Generated file. DO NOT EDIT.
+
+package client
+
+import (
+	"context"
+
+	"github.com/deref/exo/internal/compstate/api"
+	josh "github.com/deref/exo/internal/josh/client"
+)
+
+type Store struct {
+	client *josh.Client
+}
+
+var _ api.Store = (*Store)(nil)
+
+func GetStore(client *josh.Client) *Store {
+	return &Store{
+		client: client,
+	}
+}
+
+func (c *Store) SetState(ctx context.Context, input *api.SetStateInput) (output *api.SetStateOutput, err error) {
+	err = c.client.Invoke(ctx, "set-state", input, &output)
+	return
+}
+
+func (c *Store) GetStates(ctx context.Context, input *api.GetStatesInput) (output *api.GetStatesOutput, err error) {
+	err = c.client.Invoke(ctx, "get-states", input, &output)
+	return
+}

--- a/internal/compstate/peer/main.go
+++ b/internal/compstate/peer/main.go
@@ -6,9 +6,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/deref/exo/internal/eventd/api"
-	"github.com/deref/exo/internal/eventd/sqlite"
-	"github.com/deref/exo/internal/gensym"
+	"github.com/deref/exo/internal/compstate/api"
+	"github.com/deref/exo/internal/compstate/sqlite"
 	josh "github.com/deref/exo/internal/josh/server"
 	"github.com/deref/exo/internal/telemetry"
 	"github.com/deref/exo/internal/util/cmdutil"
@@ -20,13 +19,11 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// NOTE [JOSH_CONTEXT]: These should not be necessary, the Josh machinery
-	// should not be dependent on these, but rather should have some kind of
-	// middleware.
+	// SEE NOTE: [JOSH_CONTEXT].
 	ctx = logging.ContextWithLogger(ctx, logging.Default())
 	ctx = telemetry.ContextWithTelemetry(ctx, &telemetry.Nop{})
 
-	dbPath := "/tmp/exo-dev-eventd.sqlite3"
+	dbPath := "/tmp/exo-dev-compstate.sqlite3"
 	db, err := sqlx.Open("sqlite3", dbPath)
 	if err != nil {
 		cmdutil.Fatalf("error opening sqlite db: %v", err)
@@ -34,8 +31,7 @@ func main() {
 	defer db.Close()
 
 	store := &sqlite.Store{
-		DB:    db,
-		IDGen: gensym.NewULIDGenerator(ctx),
+		DB: db,
 	}
 
 	if err := store.Migrate(ctx); err != nil {

--- a/internal/compstate/sqlite/migrate.go
+++ b/internal/compstate/sqlite/migrate.go
@@ -1,0 +1,23 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+)
+
+func (sto *Store) Migrate(ctx context.Context) error {
+	if _, err := sto.DB.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS component_state (
+			component_id TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			type TEXT NOT NULL,
+			content TEXT NOT NULL,
+			tags TEXT NOT NULL,
+			timestamp INTEGER NOT NULL,
+
+			PRIMARY KEY ( component_id, version )
+		);`); err != nil {
+		return fmt.Errorf("creating component_state table: %w", err)
+	}
+	return nil
+}

--- a/internal/compstate/sqlite/store.go
+++ b/internal/compstate/sqlite/store.go
@@ -1,0 +1,100 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/deref/exo/internal/compstate/api"
+	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/exo/internal/util/mathutil"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type Store struct {
+	DB *sqlx.DB
+}
+
+func (sto *Store) SetState(ctx context.Context, input *api.SetStateInput) (*api.SetStateOutput, error) {
+	if input.ComponentID == "" {
+		return nil, fmt.Errorf("invalid component id: %q", input.ComponentID)
+	}
+	tagsJSON := "{}"
+	if input.Tags != nil {
+		tagsJSON = jsonutil.MustMarshalString(input.Tags)
+	}
+	tx, err := sto.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+	row := sto.DB.QueryRowContext(ctx, `
+		INSERT INTO component_state (
+			component_id, version,
+			type, content, tags, timestamp
+		)
+		VALUES (
+			?, COALESCE((
+					SELECT MAX(version) + 1
+					FROM component_state
+					WHERE component_id = ?
+				), 1),
+			?, ?, ?, ?
+		)
+		RETURNING version;
+	`, input.ComponentID, input.ComponentID, input.Type, input.Content, tagsJSON, input.Timestamp)
+	var output api.SetStateOutput
+	if err := row.Scan(&output.Version); err != nil {
+		return nil, fmt.Errorf("scanning: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing: %w", err)
+	}
+	return &output, nil
+}
+
+func (sto *Store) GetStates(ctx context.Context, input *api.GetStatesInput) (*api.GetStatesOutput, error) {
+	limit := mathutil.IntClamp(input.History, 1, 10)
+	maxVersion := int(math.MaxInt32)
+	if input.Version > 0 {
+		maxVersion = input.Version
+	}
+	rows, err := sto.DB.QueryContext(ctx, `
+		SELECT
+			component_id,
+			version,
+			type,
+			content,
+			tags,
+			timestamp
+		FROM component_state
+		WHERE component_id = ?
+		AND version <= ?
+		ORDER BY version DESC
+		LIMIT ?
+		`,
+		input.ComponentID, maxVersion, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	output := api.GetStatesOutput{
+		States: make([]api.State, 0, limit),
+	}
+	for rows.Next() {
+		var state api.State
+		var tags string
+		if err := rows.Scan(&state.ComponentID, &state.Version, &state.Type, &state.Content, &tags, &state.Timestamp); err != nil {
+			return nil, err
+		}
+		if err := jsonutil.UnmarshalString(tags, &state.Tags); err != nil {
+			return nil, fmt.Errorf("unmarshalling state version %d tags: %w", state.Version, err)
+		}
+		output.States = append(output.States, state)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return &output, nil
+}


### PR DESCRIPTION
This is very much work-in-progress. Just sharing for awareness and potential feedback.

The new interface in this PR supports component state storage independent from specification. This simplifies/isolates the logic for state handling. The new interface supports _historical_ states, which will be useful for debugging. Isolated state storage also means that we may be able to support _remote_ state storage, which is important for stacks shared between multiple users in a deployment scenario.

The intention is that many controller actions should be able to operate entirely on state without component specifications. This means that existing controllers might have to change to copy some additional information into the state to make that possible. This will help with recovering from bad specs (#270).

This PR is safe to land, but isn't necessarily worth it to do so, since the new state storage interface isn't actually in use yet. To avoid complex multi-stage migrations, I'll probably storm forward with the new component storage step as well, before merging or after merging, but before switching over.

To be clear: This is step 1, extracted from a very large refactor.