### PR TITLE
Control message not function

### DIFF
--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -451,15 +451,13 @@ type WorkspaceDescription struct {
 }
 
 type ComponentDescription struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Type        string   `json:"type"`
-	Spec        string   `json:"spec"`
-	State       string   `json:"state"`
-	Created     string   `json:"created"`
-	Initialized *string  `json:"initialized"`
-	Disposed    *string  `json:"disposed"`
-	DependsOn   []string `json:"dependsOn"`
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Type      string   `json:"type"`
+	Spec      string   `json:"spec"`
+	State     string   `json:"state"`
+	Created   string   `json:"created"`
+	DependsOn []string `json:"dependsOn"`
 }
 
 type StreamDescription struct {

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -84,7 +84,7 @@ type Workspace interface {
 	Builder
 	// Describes this workspace.
 	Describe(context.Context, *DescribeInput) (*DescribeOutput, error)
-	// Asynchronously deletes all components in the workspace, then deletes the workspace itself.
+	// Dispose resources, then delete the record of it.
 	Destroy(context.Context, *DestroyInput) (*DestroyOutput, error)
 	// Performs creates, updates, refreshes, disposes, as needed.
 	Apply(context.Context, *ApplyInput) (*ApplyOutput, error)

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -245,8 +245,6 @@ struct "component-description" {
   field "spec" "string" {}
   field "state" "string" {}
   field "created" "string" {}
-  field "initialized" "*string" {}
-  field "disposed" "*string" {}
   field "depends-on" "[]string" {}
 }
 

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -38,8 +38,7 @@ interface "workspace" {
   }
 
   method "destroy" {
-    doc = "Asynchronously deletes all components in the workspace, then deletes the workspace itself."
-
+    doc = "Dispose resources, then delete the record of it."
     output "job-id" "string" {}
   }
 

--- a/internal/core/server/controller.go
+++ b/internal/core/server/controller.go
@@ -3,6 +3,4 @@ package server
 type Controller interface {
 	InitResource() error
 	MarshalState() (state string, err error)
-	IsDeleted() bool
-	MarkDeleted()
 }

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -336,15 +336,13 @@ func (ws *Workspace) DescribeComponents(ctx context.Context, input *api.Describe
 	}
 	for i, component := range stateOutput.Components {
 		output.Components[i] = api.ComponentDescription{
-			ID:          component.ID,
-			Name:        component.Name,
-			Type:        component.Type,
-			Spec:        component.Spec,
-			State:       component.State,
-			Created:     component.Created,
-			Initialized: component.Initialized,
-			Disposed:    component.Disposed,
-			DependsOn:   component.DependsOn,
+			ID:        component.ID,
+			Name:      component.Name,
+			Type:      component.Type,
+			Spec:      component.Spec,
+			State:     component.State,
+			Created:   component.Created,
+			DependsOn: component.DependsOn,
 		}
 	}
 	return output, nil
@@ -519,15 +517,6 @@ func (ws *Workspace) createComponent(ctx context.Context, component manifest.Com
 		}); err != nil {
 			ws.logEventf(ctx, "error creating %s: %v", component.Name, err)
 			job.Fail(err)
-			return
-		}
-
-		// XXX this now double-patches the component to set Initialized timestamp. Optimize?
-		if _, err := ws.Store.PatchComponent(ctx, &state.PatchComponentInput{
-			ID:          id,
-			Initialized: chrono.NowString(ctx),
-		}); err != nil {
-			job.Fail(fmt.Errorf("modifying component after initialization: %w", err)) // XXX this message seems incorrect.
 			return
 		}
 

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -88,11 +88,9 @@ type AddComponentOutput struct {
 }
 
 type PatchComponentInput struct {
-	ID          string    `json:"id"`
-	State       string    `json:"state"`
-	Initialized string    `json:"initialized"`
-	Disposed    string    `json:"disposed"`
-	DependsOn   *[]string `json:"dependsOn"`
+	ID        string    `json:"id"`
+	State     string    `json:"state"`
+	DependsOn *[]string `json:"dependsOn"`
 }
 
 type PatchComponentOutput struct {
@@ -149,7 +147,5 @@ type ComponentDescription struct {
 	Spec        string   `json:"spec"`
 	State       string   `json:"state"`
 	Created     string   `json:"created"`
-	Initialized *string  `json:"initialized"`
-	Disposed    *string  `json:"disposed"`
 	DependsOn   []string `json:"dependsOn"`
 }

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -53,8 +53,6 @@ interface "store" {
   method "patch-component" {
 	  input "id" "string" {}
 	  input "state" "string" {}
-	  input "initialized" "string" {}
-	  input "disposed" "string" {}
 	  input "depends-on" "*[]string" {}
   }
 
@@ -78,7 +76,5 @@ struct "component-description" {
 	field "spec" "string" {}
 	field "state" "string" {}
 	field "created" "string" {}
-	field "initialized" "*string" {}
-	field "disposed" "*string" {}
 	field "depends-on" "[]string" {}
 }

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -35,14 +35,12 @@ type Root struct {
 }
 
 type Component struct {
-	Name        string   `json:"name"`
-	Type        string   `json:"type"`
-	Spec        string   `json:"spec"`
-	State       string   `json:"state"`
-	Created     string   `json:"created"`
-	Initialized *string  `json:"initialized"`
-	Disposed    *string  `json:"disposed"`
-	DependsOn   []string `json:"dependsOn"`
+	Name      string   `json:"name"`
+	Type      string   `json:"type"`
+	Spec      string   `json:"spec"`
+	State     string   `json:"state"`
+	Created   string   `json:"created"`
+	DependsOn []string `json:"dependsOn"`
 }
 
 func (c *Component) getDescription(id, workspaceID string) state.ComponentDescription {
@@ -54,8 +52,6 @@ func (c *Component) getDescription(id, workspaceID string) state.ComponentDescri
 		Spec:        c.Spec,
 		State:       c.State,
 		Created:     c.Created,
-		Initialized: c.Initialized,
-		Disposed:    c.Disposed,
 		DependsOn:   c.DependsOn,
 	}
 }
@@ -398,12 +394,6 @@ func (sto *Store) PatchComponent(ctx context.Context, input *state.PatchComponen
 		component := workspace.Components[input.ID]
 		if component == nil {
 			return errors.New("corrupt state: component not in workspace")
-		}
-		if input.Initialized != "" {
-			component.Initialized = &input.Initialized // TODO: Validate iso8601.
-		}
-		if input.Disposed != "" {
-			component.Disposed = &input.Disposed // TODO: Validate iso8601.
 		}
 		if input.DependsOn != nil {
 			component.DependsOn = *input.DependsOn

--- a/internal/josh/server/dynamic.go
+++ b/internal/josh/server/dynamic.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func Send(ctx context.Context, self interface{}, input interface{}) (output interface{}, err error) {
+	selfV := reflect.ValueOf(self)
+	inV := reflect.ValueOf(input)
+	inT := inV.Type()
+	if inT.Kind() != reflect.Ptr {
+		panic(fmt.Errorf("expected input to be a pointer, got %s", inT.Kind()))
+	}
+	inT = inT.Elem()
+	methodName := strings.TrimSuffix(inT.Name(), "Input")
+	if methodName == inT.Name() {
+		panic(fmt.Errorf("expected Input structure, got %T", input))
+	}
+	method := selfV.MethodByName(methodName)
+	results := method.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		inV,
+	})
+	if len(results) != 2 {
+		panic("expected 2 results")
+	}
+	output = results[0].Interface()
+	errV := results[1]
+	if !errV.IsNil() {
+		err = errV.Interface().(error)
+	}
+	return
+}

--- a/internal/providers/core/component.go
+++ b/internal/providers/core/component.go
@@ -10,10 +10,6 @@ import (
 type Component interface {
 	GetComponentID() string
 	GetComponentName() string
-
-	// TODO: Rethink these.
-	IsDeleted() bool
-	MarkDeleted()
 }
 
 type ComponentBase struct {
@@ -33,14 +29,6 @@ func (c ComponentBase) GetComponentID() string {
 
 func (c ComponentBase) GetComponentName() string {
 	return c.ComponentName
-}
-
-func (c *ComponentBase) IsDeleted() bool {
-	return c.isDeleted
-}
-
-func (c *ComponentBase) MarkDeleted() {
-	c.isDeleted = true
 }
 
 func (c *ComponentBase) Build(ctx context.Context, input *api.BuildInput) (*api.BuildOutput, error) {

--- a/internal/providers/core/components/invalid/component.go
+++ b/internal/providers/core/components/invalid/component.go
@@ -11,9 +11,3 @@ func (invalid *Invalid) InitResource() error {
 func (invalid *Invalid) MarshalState() (state string, err error) {
 	return "", invalid.Err
 }
-
-func (invalid *Invalid) IsDeleted() bool {
-	return true
-}
-
-func (invalid *Invalid) MarkDeleted() {}


### PR DESCRIPTION
Goal is to substantially simplify the internals of the workspace implementation by insisting that components are controlled exclusively by message sends, instead of by arbitrary callback functions. This PR is a first step.

Turns out that this was relatively close to true already, minus some error handling and some create/initialize/dispose/delete weirdness.