### PR TITLE
Delete all component types in GUI

### DIFF
--- a/gui/src/components/ComponentTable.svelte
+++ b/gui/src/components/ComponentTable.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import type { SvelteConstructor } from '../lib/svelte';
-  import CheckeredTableWrapper from './CheckeredTableWrapper.svelte';
-  import ErrorLabel from './ErrorLabel.svelte';
   import Spinner from './Spinner.svelte';
+  import ErrorLabel from './ErrorLabel.svelte';
+  import IconButton from './IconButton.svelte';
+  import CheckeredTableWrapper from './CheckeredTableWrapper.svelte';
+  import type { IconGlyph } from './Icon.svelte';
+  import type { SvelteConstructor } from '../lib/svelte';
 
   type Item = $$Generic;
 
@@ -12,14 +14,21 @@
     getValue: (item: Item) => T;
   }
 
+  interface Action<T> {
+    tooltip: string;
+    glyph: IconGlyph;
+    callback(component: any): any;
+  }
+
   export let load: () => Promise<Item[]>;
 
   export let columns: Column<any>[];
+  export let actions: Action<any>[] | undefined;
 
-  const components = load();
+  let componentsPromise = load();
 </script>
 
-{#await components}
+{#await componentsPromise}
   <Spinner />
 {:then components}
   {#if components.length === 0}
@@ -34,6 +43,9 @@
                 {column.title}
               </th>
             {/each}
+            {#if actions && actions.length > 0}
+              <th />
+            {/if}
           </tr>
         </thead>
         <tbody>
@@ -47,6 +59,19 @@
                   />
                 </td>
               {/each}
+              {#if actions && actions.length > 0}
+                <td class="actions">
+                  {#each actions as action}
+                    <IconButton
+                      tooltip={action.tooltip}
+                      glyph={action.glyph}
+                      on:click={() => {
+                        action.callback(component);
+                      }}
+                    />
+                  {/each}
+                </td>
+              {/if}
             </tr>
           {/each}
         </tbody>
@@ -56,3 +81,9 @@
 {:catch ex}
   <ErrorLabel value={ex} />
 {/await}
+
+<style>
+  td.actions {
+    padding: 4px 8px;
+  }
+</style>

--- a/gui/src/pages/WorkspaceComponents.svelte
+++ b/gui/src/pages/WorkspaceComponents.svelte
@@ -35,6 +35,16 @@
           getValue: (component) => component.type,
         },
       ]}
+      actions={[
+        {
+          tooltip: 'Delete component',
+          glyph: 'Delete',
+          callback: async (component) => {
+            await workspace.deleteComponent(component.id);
+            window.location.reload();
+          },
+        },
+      ]}
     />
   </Panel>
 </Layout>

--- a/gui/src/pages/WorkspaceNetworking.svelte
+++ b/gui/src/pages/WorkspaceNetworking.svelte
@@ -30,6 +30,7 @@
           getValue: (network) => network.name,
         },
       ]}
+      actions={[]}
     />
   </Panel>
 </Layout>

--- a/gui/src/pages/WorkspaceNetworking.svelte
+++ b/gui/src/pages/WorkspaceNetworking.svelte
@@ -30,7 +30,16 @@
           getValue: (network) => network.name,
         },
       ]}
-      actions={[]}
+      actions={[
+        {
+          tooltip: 'Delete network',
+          glyph: 'Delete',
+          callback: async (component) => {
+            await workspace.deleteComponent(component.id);
+            window.location.reload();
+          },
+        },
+      ]}
     />
   </Panel>
 </Layout>

--- a/gui/src/pages/WorkspaceStorage.svelte
+++ b/gui/src/pages/WorkspaceStorage.svelte
@@ -30,6 +30,16 @@
           getValue: (volume) => volume.name,
         },
       ]}
+      actions={[
+        {
+          tooltip: 'Delete volume',
+          glyph: 'Delete',
+          callback: async (component) => {
+            await workspace.deleteComponent(component.id);
+            window.location.reload();
+          },
+        },
+      ]}
     />
   </Panel>
 </Layout>


### PR DESCRIPTION
This adds an optional `actions` column to the `ComponentTable`s, allowing for arbitrary actions to be taken with icon buttons for each table row.

I've added delete for each component type, to the "Components", "Networking", and "Storage" tabs.

![image](https://user-images.githubusercontent.com/51100181/135860547-cc49f230-0970-4c97-9608-ba05d39e2396.png)

However, I don't think we should combine this table data view with CRUD actions like this - not sure.
I think it's probably better if:

1. the components page goes away, and we expand the list of components in the workspace home page from only runnables to all components.
2. we can either delete or keep the Networking and Storage pages, but it doesn't really add much to have them exist until we can show specific information about networking and storage. For example, if we do have a storage page with a table of volumes and other storage components, we should probably do something like show bars for their relative total storage size or something.