### PR TITLE
Add basic support for exo secrets vault

### DIFF
--- a/cmd/exo/secrets.go
+++ b/cmd/exo/secrets.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(secretsCmd)
+}
+
+type deviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+var clientId = "LNPi71pWh6trIbZOGxxGi5eilI5DakWE"
+
+func requestDeviceCode() (deviceCodeResponse, error) {
+	url := "https://deref.us.auth0.com/oauth/device/code"
+
+	payloadString := fmt.Sprintf("client_id=%s&scope=profile&audience=cli-client", clientId)
+	payload := strings.NewReader(payloadString)
+	req, _ := http.NewRequest("POST", url, payload)
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return deviceCodeResponse{}, fmt.Errorf("getting auth URL: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return deviceCodeResponse{}, fmt.Errorf("unexpected %d status code when getting auth URL", res.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return deviceCodeResponse{}, fmt.Errorf("reading body: %w", err)
+	}
+
+	codeResult := deviceCodeResponse{}
+	if err := json.Unmarshal(body, &codeResult); err != nil {
+		return deviceCodeResponse{}, fmt.Errorf("unmarshalling auth URL response: %w", err)
+	}
+
+	return codeResult, nil
+}
+
+func requestTokens(deviceCode string, interval int) (tokenResponse, error) {
+	uri := "https://deref.us.auth0.com/oauth/token"
+	values := url.Values{}
+	values.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	values.Set("device_code", deviceCode)
+	values.Set("client_id", clientId)
+	payloadString := values.Encode()
+
+	for {
+		// A new request object must be made for each request made.
+		req, err := http.NewRequest("POST", uri, strings.NewReader(payloadString))
+		if err != nil {
+			return tokenResponse{}, fmt.Errorf("making request: %w", err)
+		}
+
+		req.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return tokenResponse{}, fmt.Errorf("making token request: %w", err)
+		}
+
+		defer res.Body.Close()
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return tokenResponse{}, fmt.Errorf("reading body: %w", err)
+		}
+
+		if res.StatusCode == 200 {
+			tokens := tokenResponse{}
+			if err := json.Unmarshal(body, &tokens); err != nil {
+				return tokenResponse{}, fmt.Errorf("unmarshalling auth token response: %w", err)
+			}
+			return tokens, nil
+		}
+
+		type errResponseStruct struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+
+		errResp := errResponseStruct{}
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			return tokenResponse{}, fmt.Errorf("unmarshalling auth token error response: %w", err)
+		}
+
+		if errResp.Error != "authorization_pending" {
+			return tokenResponse{}, fmt.Errorf("unexpected error %s: %s", errResp.Error, errResp.ErrorDescription)
+		}
+
+		time.Sleep(time.Second * time.Duration(interval))
+	}
+}
+
+var secretsCmd = &cobra.Command{
+	Use:  "secrets",
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		accessToken, err := ioutil.ReadFile("exo-secrets.json")
+		if err != nil {
+			if os.IsNotExist(err) {
+				codeResponse, err := requestDeviceCode()
+				if err != nil {
+					return fmt.Errorf("getting device code: %w", err)
+				}
+
+				fmt.Println("Open the following URL to authenticate:")
+				fmt.Println(codeResponse.VerificationURIComplete)
+
+				tokens, err := requestTokens(codeResponse.DeviceCode, codeResponse.Interval)
+				if err != nil {
+					return fmt.Errorf("getting tokens: %w", err)
+				}
+
+				fmt.Printf("tokens: %+v\n", tokens)
+
+				err = ioutil.WriteFile(filepath.Join(cfg.VarDir, "secret-token"), []byte(tokens.AccessToken), 0600)
+				if err != nil {
+					return fmt.Errorf("writing secrets: %w", err)
+				}
+
+				accessToken = []byte(tokens.AccessToken)
+			}
+		}
+
+		req, _ := http.NewRequest("POST", "http://localhost:5000/api/_exo/describe-me", bytes.NewBufferString(""))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+string(accessToken))
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("making token request: %w", err)
+
+		}
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		fmt.Printf("body: %+v\n", string(body))
+
+		return nil
+	},
+}

--- a/internal/esv/client.go
+++ b/internal/esv/client.go
@@ -1,0 +1,105 @@
+package esv
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type EsvClient struct {
+	AccessKey string
+}
+
+func (c *EsvClient) runCommand(output interface{}, host, commandName string, body interface{}) error {
+	marshalledBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshalling command body: %w", err)
+	}
+
+	req, _ := http.NewRequest("POST", host+"/api/_exo/"+commandName, bytes.NewBuffer(marshalledBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.AccessKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("making token request: %w", err)
+	}
+
+	result, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading command result: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(result), output); err != nil {
+		return fmt.Errorf("unmarshalling command result: %w", err)
+	}
+
+	return nil
+
+}
+
+func (c *EsvClient) GetWorkspaceSecrets(projectURL string) (map[string]string, error) {
+	type describeProjectResp struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+		Secrets     []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+		} `json:"secrets"`
+	}
+
+	organizationID, projectID, err := getIdsFromUrl(projectURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not find IDs: %w", err)
+	}
+
+	uri, err := url.Parse(projectURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing secrets URL: %w", err)
+	}
+	host := url.URL{Scheme: uri.Scheme, Host: uri.Host}
+
+	resp := describeProjectResp{}
+	err = c.runCommand(&resp, host.String(), "describe-project", map[string]string{
+		"organizationId": organizationID,
+		"projectId":      projectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("running describe-project command: %w", err)
+	}
+	secrets := map[string]string{}
+	for _, secret := range resp.Secrets {
+		secrets[secret.DisplayName] = secret.ID
+	}
+	return secrets, nil
+}
+
+func getIdsFromUrl(projectURL string) (organizationID, projectID string, err error) {
+	parsedUrl, err := url.Parse(projectURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing project URL: %w", err)
+	}
+
+	parts := strings.Split(parsedUrl.Path, "/")
+	for i, part := range parts {
+		if part == "organizations" {
+			if i+1 < len(parts) {
+				organizationID = parts[i+1]
+			}
+		}
+		if part == "projects" {
+			if i+1 < len(parts) {
+				projectID = parts[i+1]
+			}
+		}
+		if organizationID != "" && projectID != "" {
+			return
+		}
+	}
+	err = fmt.Errorf("could not find IDs in URL: %q", projectURL)
+	return
+}


### PR DESCRIPTION
Some TODOs remain but this is a working implementation of authing via `exo` and making secrets available in the environment.