### PR TITLE
add compose interpolation for generic yaml structures

### DIFF
--- a/internal/providers/docker/compose/interpolate/doc.go
+++ b/internal/providers/docker/compose/interpolate/doc.go
@@ -1,0 +1,9 @@
+// Package inteprolate implements recursive string substitution templating of
+// yaml documents. The string template language is in the style of Python's
+// string.Template library as extended by Docker Compose.
+//
+// References:
+// - https://github.com/docker/compose/blob/4a51af09d6cdb9407a6717334333900327bc9302/compose/config/interpolation.py
+// - https://docs.python.org/3/library/string.html#string.Template
+// - https://github.com/compose-spec/compose-spec/blob/b369fe5e02d80b619d14974cd1e64e7eea1b2345/spec.md#interpolation
+package interpolate

--- a/internal/providers/docker/compose/interpolate/environment.go
+++ b/internal/providers/docker/compose/interpolate/environment.go
@@ -1,4 +1,4 @@
-package template
+package interpolate
 
 type Environment interface {
 	Lookup(key string) (value string, found bool)

--- a/internal/providers/docker/compose/interpolate/interpolate.go
+++ b/internal/providers/docker/compose/interpolate/interpolate.go
@@ -1,0 +1,72 @@
+package interpolate
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func Interpolate(v interface{}, env Environment) error {
+	r := &interpolator{
+		env: env,
+	}
+	_, err := r.interpolate(v)
+	return err
+}
+
+type interpolator struct {
+	env  Environment
+	path []string
+}
+
+func (r *interpolator) errorf(format string, v ...interface{}) error {
+	return fmt.Errorf("at %v: "+format, append([]interface{}{r.path}, v...)...)
+}
+
+func (r *interpolator) interpolate(v interface{}) (interface{}, error) {
+	switch v := v.(type) {
+	case bool, int, uint, int32, uint32, int64, uint64, float32, float64:
+		return v, nil
+
+	case string:
+		tmpl, err := NewTemplate(v)
+		if err != nil {
+			return nil, r.errorf("compiling template: %w", err)
+		}
+		res, err := Substitute(tmpl, r.env)
+		if err != nil {
+			return nil, r.errorf("substituting: %w", err)
+		}
+		return res, nil
+
+	case map[string]interface{}:
+		n := len(r.path)
+		r.path = append(r.path, "")
+		for k, x := range v {
+			r.path[n] = k
+			y, err := r.interpolate(x)
+			if err != nil {
+				return nil, err
+			}
+			v[k] = y
+		}
+		r.path = r.path[:n]
+		return v, nil
+
+	case []interface{}:
+		n := len(r.path)
+		r.path = append(r.path, "")
+		for i, x := range v {
+			r.path[n] = strconv.Itoa(i)
+			y, err := r.interpolate(x)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = y
+		}
+		r.path = r.path[:n]
+		return v, nil
+
+	default:
+		return nil, r.errorf("cannot interpolate value of type: %T", v)
+	}
+}

--- a/internal/providers/docker/compose/interpolate/interpolate_test.go
+++ b/internal/providers/docker/compose/interpolate/interpolate_test.go
@@ -1,0 +1,43 @@
+package interpolate
+
+import (
+	"testing"
+
+	"github.com/deref/exo/internal/util/yamlutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterpolate(t *testing.T) {
+	expected := map[string]interface{}{
+		"foo": uint64(123),
+		"bar": "i",
+		"array": []interface{}{
+			"foo",
+			"v",
+			"bar",
+		},
+		"map": map[string]interface{}{
+			"key":              "x",
+			"$notInterpolated": "xyz",
+		},
+	}
+	env := MapEnvironment(map[string]string{
+		"one":  "i",
+		"five": "v",
+		"ten":  "x",
+	})
+	var v interface{}
+	yamlutil.MustUnmarshalString(`
+foo: 123
+bar: $one
+array:
+  - foo
+  - $five
+  - bar
+map:
+  key: $ten
+  $notInterpolated: xyz
+`, &v)
+	assert.NoError(t, Interpolate(v, env))
+	assert.Equal(t, expected, v)
+}

--- a/internal/providers/docker/compose/interpolate/template.go
+++ b/internal/providers/docker/compose/interpolate/template.go
@@ -1,11 +1,4 @@
-// Package template implements string substitution templating in the style of
-// Python's string.Template library as extended by Docker Compose.
-//
-// References:
-// - https://github.com/docker/compose/blob/4a51af09d6cdb9407a6717334333900327bc9302/compose/config/interpolation.py
-// - https://docs.python.org/3/library/string.html#string.Template
-// - https://github.com/compose-spec/compose-spec/blob/b369fe5e02d80b619d14974cd1e64e7eea1b2345/spec.md#interpolation
-package template
+package interpolate
 
 import (
 	"bytes"
@@ -25,7 +18,7 @@ func Substitute(template Template, env Environment) (string, error) {
 	return buf.String(), err
 }
 
-func New(s string) (Template, error) {
+func NewTemplate(s string) (Template, error) {
 	var elements []Template
 	matches := pattern.FindAllStringSubmatchIndex(s, -1)
 	left := 0

--- a/internal/providers/docker/compose/interpolate/template_test.go
+++ b/internal/providers/docker/compose/interpolate/template_test.go
@@ -1,4 +1,4 @@
-package template
+package interpolate
 
 import (
 	"testing"
@@ -40,7 +40,7 @@ func TestTemplate(t *testing.T) {
 		{"prefix${ten}suffix", "prefix10suffix", map[string]string{"ten": "10"}},
 	}
 	for _, test := range okTests {
-		tmpl, err := New(test.Template)
+		tmpl, err := NewTemplate(test.Template)
 		assert.NoError(t, err)
 		actual, err := Substitute(tmpl, MapEnvironment(test.Env))
 		assert.NoError(t, err)
@@ -56,7 +56,7 @@ func TestTemplate(t *testing.T) {
 		{"${x:?some error}", "some error", map[string]string{"x": ""}},
 	}
 	for _, test := range errTests {
-		tmpl, err := New(test.Template)
+		tmpl, err := NewTemplate(test.Template)
 		assert.NoError(t, err)
 		_, err = Substitute(tmpl, MapEnvironment(test.Env))
 		assert.EqualError(t, err, test.Message, "test=%#v", test)


### PR DESCRIPTION
This is extracted from the previously reviewed PR #266. It's just the isolated subset of the code that deals with compose-style interpolation of generic Yaml structures. It is presently unused, like the rest of the Python-style templating/substitution primitives in the same package. I'm getting this to main separately because it is stable, unlike the rest of the interpolation branch which needs some reworking.