### PR TITLE
Fix compose.Ulimits to be stable in tests.

### DIFF
--- a/internal/providers/docker/components/container/lifecycle.go
+++ b/internal/providers/docker/components/container/lifecycle.go
@@ -552,12 +552,14 @@ func convertUlimits(in compose.Ulimits) []*units.Ulimit {
 	}
 
 	out := make([]*units.Ulimit, len(in))
-	for i, ulimit := range in {
+	i := 0
+	for name, ulimit := range in {
 		out[i] = &units.Ulimit{
-			Name: ulimit.Name,
+			Name: name,
 			Hard: ulimit.Hard,
 			Soft: ulimit.Soft,
 		}
+		i++
 	}
 
 	return out

--- a/internal/providers/docker/compose/project_test.go
+++ b/internal/providers/docker/compose/project_test.go
@@ -551,13 +551,11 @@ pids_limit: 5280`,
     hard: 40000`,
 			expected: compose.Service{
 				Ulimits: compose.Ulimits{
-					{
-						Name: "nproc",
+					"nproc": {
 						Soft: 65535,
 						Hard: 65535,
 					},
-					{
-						Name: "nofile",
+					"nofile": {
 						Soft: 20000,
 						Hard: 40000,
 					},

--- a/internal/providers/docker/compose/ulimit.go
+++ b/internal/providers/docker/compose/ulimit.go
@@ -1,39 +1,29 @@
 package compose
 
-import (
-	"github.com/goccy/go-yaml"
-)
-
-type Ulimits []Ulimit
+type Ulimits map[string]Ulimit
 
 type Ulimit struct {
-	Name string
 	Hard int64
 	Soft int64
 }
 
-func (u *Ulimits) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var asMap yaml.MapSlice
-	if err := unmarshal(&asMap); err != nil {
+func (u *Ulimit) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var n int64
+	err := unmarshal(&n)
+	if err == nil {
+		u.Hard = n
+		u.Soft = n
 		return err
 	}
 
-	ulimits := make([]Ulimit, len(asMap))
-	for i, item := range asMap {
-		ulimit := Ulimit{
-			Name: item.Key.(string),
-		}
-		switch val := item.Value.(type) {
-		case uint64:
-			ulimit.Hard = int64(val)
-			ulimit.Soft = int64(val)
-		case map[string]interface{}:
-			ulimit.Hard = int64(val["hard"].(uint64))
-			ulimit.Soft = int64(val["soft"].(uint64))
-		}
-		ulimits[i] = ulimit
+	var m struct {
+		Hard int64 `ymal:"hard,omitempty"`
+		Soft int64 `ymal:"soft,omitempty"`
 	}
-	*u = ulimits
-
+	if err := unmarshal(&m); err != nil {
+		return err
+	}
+	u.Hard = m.Hard
+	u.Soft = m.Soft
 	return nil
 }


### PR DESCRIPTION
Extracting from #266 - this seems to work for some unknown reason in tests today, but any tiny change causes the order of the map elements to flip around or become unstable, so this makes the tests less flakey.