### PR TITLE
Rename

### DIFF
--- a/cmd/exo/edit.go
+++ b/cmd/exo/edit.go
@@ -42,6 +42,7 @@ var editCmd = &cobra.Command{
 			Ref:  component.ID,
 			Spec: newSpec,
 		})
+		// TODO: This should handle a job id for the update step.
 		return err
 	},
 }

--- a/cmd/exo/rename.go
+++ b/cmd/exo/rename.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/deref/exo/internal/core/api"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(renameCmd)
+}
+
+var renameCmd = &cobra.Command{
+	Use:   "rename <ref> <new-name>",
+	Short: "Rename component",
+	Long:  "Rename components.",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := newContext()
+		checkOrEnsureServer()
+		cl := newClient()
+		workspace := requireCurrentWorkspace(ctx, cl)
+		_, err := workspace.RenameComponent(ctx, &api.RenameComponentInput{
+			Ref:  args[0],
+			Name: args[1],
+		})
+		return err
+	},
+}

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -189,7 +189,11 @@ type CreateComponentOutput struct {
 }
 
 type UpdateComponentInput struct {
-	Ref       string   `json:"ref"`
+
+	// Refers to the component to be updated.
+	Ref string `json:"ref"`
+	// If provided, renames the component.
+	Name      string   `json:"name"`
 	Spec      string   `json:"spec"`
 	DependsOn []string `json:"dependsOn"`
 }

--- a/internal/core/api/workspace.go
+++ b/internal/core/api/workspace.go
@@ -96,6 +96,7 @@ type Workspace interface {
 	CreateComponent(context.Context, *CreateComponentInput) (*CreateComponentOutput, error)
 	// Replaces the spec on a component and triggers an update lifecycle event.
 	UpdateComponent(context.Context, *UpdateComponentInput) (*UpdateComponentOutput, error)
+	RenameComponent(context.Context, *RenameComponentInput) (*RenameComponentOutput, error)
 	// Asycnhronously refreshes component state.
 	RefreshComponents(context.Context, *RefreshComponentsInput) (*RefreshComponentsOutput, error)
 	// Asynchronously runs dispose lifecycle methods on each component.
@@ -194,6 +195,17 @@ type UpdateComponentInput struct {
 }
 
 type UpdateComponentOutput struct {
+}
+
+type RenameComponentInput struct {
+
+	// Refers to the component to be renamed.
+	Ref string `json:"ref"`
+	// New name to give to the component.
+	Name string `json:"name"`
+}
+
+type RenameComponentOutput struct {
 }
 
 type RefreshComponentsInput struct {
@@ -387,6 +399,9 @@ func BuildWorkspaceMux(b *josh.MuxBuilder, factory func(req *http.Request) Works
 	})
 	b.AddMethod("update-component", func(req *http.Request) interface{} {
 		return factory(req).UpdateComponent
+	})
+	b.AddMethod("rename-component", func(req *http.Request) interface{} {
+		return factory(req).RenameComponent
 	})
 	b.AddMethod("refresh-components", func(req *http.Request) interface{} {
 		return factory(req).RefreshComponents

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -104,11 +104,25 @@ interface "workspace" {
   method "update-component" {
     doc = "Replaces the spec on a component and triggers an update lifecycle event."
 
-    input "ref" "string" {}
+    input "ref" "string" {
+      doc = "Refers to the component to be updated."
+    }
+    input "name" "string" {
+      doc = "If provided, renames the component."
+    }
     input "spec" "string" {}
     input "depends-on" "[]string" {}
 
     # TODO: output "job-id" "string" {}
+  }
+
+  method "rename-component" {
+    input "ref" "string" {
+      doc = "Refers to the component to be renamed."
+    }
+    input "name" "string" {
+      doc = "New name to give to the component."
+    }
   }
 
   method "refresh-components" {

--- a/internal/core/api/workspace.josh.hcl
+++ b/internal/core/api/workspace.josh.hcl
@@ -107,6 +107,8 @@ interface "workspace" {
     input "ref" "string" {}
     input "spec" "string" {}
     input "depends-on" "[]string" {}
+
+    # TODO: output "job-id" "string" {}
   }
 
   method "refresh-components" {

--- a/internal/core/client/workspace.go
+++ b/internal/core/client/workspace.go
@@ -130,6 +130,11 @@ func (c *Workspace) UpdateComponent(ctx context.Context, input *api.UpdateCompon
 	return
 }
 
+func (c *Workspace) RenameComponent(ctx context.Context, input *api.RenameComponentInput) (output *api.RenameComponentOutput, err error) {
+	err = c.client.Invoke(ctx, "rename-component", input, &output)
+	return
+}
+
 func (c *Workspace) RefreshComponents(ctx context.Context, input *api.RefreshComponentsInput) (output *api.RefreshComponentsOutput, err error) {
 	err = c.client.Invoke(ctx, "refresh-components", input, &output)
 	return

--- a/internal/core/server/workspace.go
+++ b/internal/core/server/workspace.go
@@ -530,10 +530,18 @@ func (ws *Workspace) UpdateComponent(ctx context.Context, input *api.UpdateCompo
 		dependsOn = input.DependsOn
 	}
 
+	newName := input.Name
+	if newName == "" {
+		newName = oldComponent.Name
+	}
+	if err := manifest.ValidateName(newName); err != nil {
+		return nil, errutil.HTTPErrorf(http.StatusBadRequest, "new component name %q is invalid: %w", newName, err)
+	}
+
 	ws.logEventf(ctx, "updating %s", oldComponent.Name)
 	if err := ws.updateComponent(ctx, oldComponent, manifest.Component{
 		Type:      oldComponent.Type,
-		Name:      oldComponent.Name,
+		Name:      newName,
 		Spec:      input.Spec,
 		DependsOn: dependsOn,
 	}, oldComponent.ID); err != nil {

--- a/internal/core/state/api/store.go
+++ b/internal/core/state/api/store.go
@@ -88,7 +88,11 @@ type AddComponentOutput struct {
 }
 
 type PatchComponentInput struct {
-	ID        string    `json:"id"`
+
+	// ID of component to be patched.
+	ID string `json:"id"`
+	// If provided, renames component.
+	Name      string    `json:"name"`
 	State     string    `json:"state"`
 	DependsOn *[]string `json:"dependsOn"`
 }

--- a/internal/core/state/api/store.josh.hcl
+++ b/internal/core/state/api/store.josh.hcl
@@ -51,7 +51,12 @@ interface "store" {
   }
 
   method "patch-component" {
-	  input "id" "string" {}
+	  input "id" "string" {
+      doc = "ID of component to be patched."
+    }
+	  input "name" "string" {
+      doc = "If provided, renames component."
+    }
 	  input "state" "string" {}
 	  input "depends-on" "*[]string" {}
   }

--- a/internal/core/state/statefile/statefile.go
+++ b/internal/core/state/statefile/statefile.go
@@ -395,6 +395,14 @@ func (sto *Store) PatchComponent(ctx context.Context, input *state.PatchComponen
 		if component == nil {
 			return errors.New("corrupt state: component not in workspace")
 		}
+		if input.Name != "" {
+			component.Name = input.Name
+			if workspace.Names == nil {
+				return errors.New("corrupt state: names missing in workspace")
+			}
+			delete(workspace.Components, component.Name)
+			workspace.Names[input.Name] = input.ID
+		}
 		if input.DependsOn != nil {
 			component.DependsOn = *input.DependsOn
 		}

--- a/internal/providers/unix/components/process/lifecycle.go
+++ b/internal/providers/unix/components/process/lifecycle.go
@@ -70,10 +70,8 @@ func (p *Process) refresh() {
 }
 
 func (p *Process) Dispose(ctx context.Context, input *core.DisposeInput) (*core.DisposeOutput, error) {
-	if p.Program == "" {
-		// SEE NOTE [PROCESS_STATE_MIGRATION].
-		return nil, errors.New("refresh needed")
+	if err := p.stop(nil); err != nil {
+		return nil, err
 	}
-	p.stop(nil)
 	return &core.DisposeOutput{}, nil
 }


### PR DESCRIPTION
Fixes some (but not all) brokenness with component editing operations & introduces two ways to rename a component:

1) `exo rename old new` which will synchronously rename a component via the `rename-component` method on a workspace.
2) Enhanced the `update-component` method to allow atomic renaming a component along with an asynchronous spec change, though spec changes are broken at the moment & will be be fixed in a follow-up. The update-component path is used by the `exo edit` command, which currently only edits the spec. The follow-up work may edit the command to allow headers to the spec file, so that the name or depends-on or other metadata attributes can be edited.