### PR TITLE
Equal installation instructions in documentation

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -3,7 +3,7 @@
 ## Quick Install
 
 ```bash
-curl -sL https://exo.deref.io/install | sh
+curl -sL https://exo.deref.io/install | bash
 ```
 
 ## Manual Installation


### PR DESCRIPTION
README.md changed the installation command to use bash in [this commit ](https://github.com/deref/exo/commit/704d65a67ea2674a5066b77f53fbaa677a0f2e7c). This PR tries to equal documentation using bash in Quick Install section of Installation document.