### PR TITLE
Fix excessive refetching causing unnecessary re-rendering.

### DIFF
--- a/gui/src/components/RemoteData.svelte
+++ b/gui/src/components/RemoteData.svelte
@@ -4,8 +4,7 @@
   type Item = $$Generic;
   interface $$Slots {
     pending: {};
-    success: { data: Item };
-    refetching: { data: Item };
+    success: { data: Item; loading: boolean };
     error: { error: string };
     default: {
       data: Item;
@@ -21,13 +20,9 @@
 
 {#if data.stage === 'pending'}
   <slot name="pending">Loading...</slot>
-{:else if data.stage === 'success'}
-  <slot name="success" data={data.data}>Missing success slot!</slot>
-{:else if data.stage === 'refetching'}
-  <slot name="refetching" data={data.data}>
-    <slot name="success" data={data.data}>
-      Missing refetching and success slots!
-    </slot>
+{:else if data.stage === 'success' || data.stage === 'refetching'}
+  <slot name="success" data={data.data} loading={data.stage == 'refetching'}>
+    Missing success slot!
   </slot>
 {:else if data.stage === 'error'}
   <slot name="error" error={data.message}>

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -35,6 +35,10 @@ interface RefetchingResponse<T> {
   data: T;
 }
 
+// TODO: This is an invalid enumeration of states. For example, this cannot
+// represent an error that is being retried. In practice, there are actually
+// three booleans for a total of nine states: (loading, !!data, and !!error).
+// Look up "SWR" for examples of how to do this better.
 export type RequestLifecycle<T> =
   | IdleRequest
   | PendingRequest


### PR DESCRIPTION
This occurred because of flagging between 'success' and 'refetching'
states, which was changing the element structure with the extra
slot=refetching wrapper.