### PR TITLE
Experiment: format directory names with `s/^`(home)`/~/g`

### DIFF
--- a/gui/src/components/FormattedDirectory.svelte
+++ b/gui/src/components/FormattedDirectory.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { api } from '../lib/api';
+
+  export let raw: string;
+</script>
+
+<span title={raw}>
+  {#await api.kernel.getUserHomeDir()}
+    {raw}
+  {:then homeDir}
+    {raw.substr(0, homeDir.length) === homeDir
+      ? '~' + raw.substr(homeDir.length)
+      : raw}
+  {/await}
+</span>

--- a/gui/src/components/WorkspaceList.svelte
+++ b/gui/src/components/WorkspaceList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as router from 'svelte-spa-router';
   import type { WorkspaceDescription } from '../lib/api';
+  import FormattedDirectory from './FormattedDirectory.svelte';
 
   export let workspaces: WorkspaceDescription[];
 </script>
@@ -16,10 +17,9 @@
       on:click={() => {
         router.push(`/workspaces/${encodeURIComponent(workspace.id)}`);
       }}
-      title={workspace.root}
     >
       <b>{workspace.displayName}</b>
-      <span>{workspace.root}</span>
+      <span><FormattedDirectory raw={workspace.root} /></span>
     </button>
   {/each}
 </div>


### PR DESCRIPTION
Not sure this is actually worth doing (at least, in this manner) but this changes a path like `/home/john/path/to/project` to `~/path/to/project` which removes a lot of repetitive, likely unimportant, information from some locations (as in the `Home` page).

Having to call the API each time for each formatted directory seems like a bad solution though.