### PR TITLE
Add Font preferences

### DIFF
--- a/gui/public/globals.css
+++ b/gui/public/globals.css
@@ -17,12 +17,15 @@ body {
   --panel-overflow-x: hidden;
   --panel-bg-color: var(--primary-bg-color);
   --preferred-ligatures-logs: none;
-  --preferres-ligatures-code: none;
+  --preferred-ligatures-code: none;
+  --preferred-main-font-size: 16px;
+  --preferred-log-font-size: 15px;
 }
 
 :root,
 body {
   font-family: var(--font-sans);
+  font-size: var(--preferred-main-font-size);
   color: var(--primary-color);
   background-color: var(--primary-bg-color);
 }

--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -19,7 +19,11 @@
 >
   <nav>
     <header>
-      <NavbarButton title="Home" href="#/" shortcutParams={{ code: 'KeyH' }}>
+      <NavbarButton
+        title="Home"
+        href="#/"
+        shortcutParams={{ control: true, code: 'KeyH' }}
+      >
         {#if import.meta.env.MODE === 'development'}
           <img src="/deref-rounded-icon-dev.png" alt="Deref" height="24px" />
         {:else}
@@ -34,7 +38,7 @@
       <NavbarButton
         title="Preferences"
         href="#/preferences"
-        shortcutParams={{ code: 'KeyP' }}
+        shortcutParams={{ control: true, code: 'KeyP' }}
       >
         <Icon glyph="Preferences" />
       </NavbarButton>

--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -3,6 +3,7 @@
   import VersionInfo from './VersionInfo.svelte';
   import NavbarButton from './nav/NavbarButton.svelte';
   import { theme, themeOptions } from '../lib/theme';
+  import { preferences } from '../lib/preferences';
 
   $: {
     for (const option of themeOptions) {
@@ -11,7 +12,11 @@
   }
 </script>
 
-<main>
+<main
+  style={Object.entries($preferences)
+    .map((x) => `--preferred-${x[0]}:${x[1]}`)
+    .join(';')}
+>
   <nav>
     <header>
       <NavbarButton title="Home" href="#/" shortcutParams={{ code: 'KeyH' }}>

--- a/gui/src/components/form/InputQuantity.svelte
+++ b/gui/src/components/form/InputQuantity.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  export let id: string | undefined = undefined;
+  export let name: string | undefined = undefined;
+  export let placeholder: string | undefined = undefined;
+
+  export let value: string;
+
+  const matchGroup = (index: 1 | 2) => {
+    if (value) {
+      const match = value.match(/([0-9]+)(\w+)/);
+
+      if (match) {
+        return match[index];
+      }
+    }
+
+    return '';
+  };
+
+  let num = matchGroup(1);
+  let unit = matchGroup(2);
+
+  export let unitOptions: string[] | undefined = undefined;
+
+  $: {
+    value = num + unit;
+  }
+</script>
+
+<input bind:value style="display:none" />
+
+<div>
+  <input
+    type="number"
+    {id}
+    bind:value={num}
+    {name}
+    {placeholder}
+    on:blur
+    on:focus
+    on:input
+  />
+
+  {#if unitOptions}
+    <select bind:value={unit}>
+      {#each unitOptions as unitOption}
+        <option value={unitOption}>{unitOption}</option>
+      {/each}
+    </select>
+  {/if}
+</div>
+
+<style>
+  input,
+  select {
+    border: none;
+    margin: 0;
+    padding: 12px 18px;
+    background: var(--primary-bg-color);
+    color: var(--strong-color);
+    box-shadow: var(--text-input-shadow);
+    width: var(--input-width);
+    height: 2.5rem;
+    outline: none;
+    width: 100%;
+  }
+
+  div {
+    display: grid;
+    grid-template-columns: auto max-content;
+    gap: 1px;
+  }
+
+  div > *:first-child {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+
+  div > *:last-child {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  input:focus,
+  input:focus-within,
+  select:focus,
+  select:focus-within {
+    box-shadow: var(--text-input-shadow-focus) !important;
+  }
+</style>

--- a/gui/src/components/form/InputSelection.svelte
+++ b/gui/src/components/form/InputSelection.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  export let id: string | undefined = undefined;
+  export let name: string | undefined = undefined;
+
+  export let value: string;
+
+  export let options: string[];
+</script>
+
+<select {id} bind:value {name} on:blur on:focus>
+  {#each options as option}
+    <option value={option}>{option}</option>
+  {/each}
+</select>
+
+<style>
+  select {
+    border: none;
+    margin: 0;
+    padding: 12px 18px;
+    background: var(--primary-bg-color);
+    color: var(--strong-color);
+    box-shadow: var(--text-input-shadow);
+    width: var(--input-width);
+    height: 2.5rem;
+    outline: none;
+    width: 100%;
+    border-radius: 4px;
+  }
+
+  select:focus,
+  select:focus-within {
+    box-shadow: var(--text-input-shadow-focus) !important;
+  }
+</style>

--- a/gui/src/components/logs/Logs.svelte
+++ b/gui/src/components/logs/Logs.svelte
@@ -63,9 +63,9 @@
   table {
     background: var(--primary-bg-color);
     font-family: var(--font-mono);
+    font-size: var(--preferred-log-font-size);
     font-variant-ligatures: var(--preferred-ligatures-logs);
     font-weight: 450;
-    font-size: 15px;
   }
 
   table {

--- a/gui/src/lib/preferences.ts
+++ b/gui/src/lib/preferences.ts
@@ -4,7 +4,7 @@ const key = 'io.deref.exo/preferences';
 
 export type Preferences = Record<string, string>;
 
-let defaults = {
+let defaults: Preferences = {
   'main-font-size': '16px',
   'log-font-size': '15px',
   'ligatures-logs': 'none',

--- a/gui/src/lib/preferences.ts
+++ b/gui/src/lib/preferences.ts
@@ -1,0 +1,42 @@
+import { writable } from 'svelte/store';
+
+const key = 'io.deref.exo/preferences';
+
+type Preferences = Record<string, string>;
+
+let defaults = {
+  'main-font-size': '16px',
+  'log-font-size': '15px',
+  'ligatures-logs': 'none',
+  'ligatures-code': 'none',
+};
+
+function createStoredPreferences() {
+  let obj: Preferences = { ...defaults };
+
+  for (const variable of Object.keys(defaults)) {
+    const localItem = localStorage.getItem(key + '/' + variable);
+
+    if (localItem !== null) {
+      obj[variable] = localItem;
+    }
+  }
+
+  const { subscribe, set } = writable<Preferences>(<Preferences>obj);
+
+  const localSyncedSet = (prefs: Preferences) => {
+    for (const variable of Object.keys(defaults)) {
+      localStorage.setItem(key + '/' + variable, prefs[variable]);
+    }
+
+    set(prefs);
+  };
+
+  return {
+    subscribe,
+    apply: (prefs: Preferences) => localSyncedSet(prefs),
+    reset: () => localSyncedSet({ ...defaults }),
+  };
+}
+
+export const preferences = createStoredPreferences();

--- a/gui/src/lib/preferences.ts
+++ b/gui/src/lib/preferences.ts
@@ -2,7 +2,7 @@ import { writable } from 'svelte/store';
 
 const key = 'io.deref.exo/preferences';
 
-type Preferences = Record<string, string>;
+export type Preferences = Record<string, string>;
 
 let defaults = {
   'main-font-size': '16px',

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -5,6 +5,7 @@
   import IconButton from '../components/IconButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
   import { theme, themeOptions } from '../lib/theme';
+  import type { Preferences } from '../lib/preferences';
   import { preferences } from '../lib/preferences';
   import { onMount } from 'svelte';
 
@@ -27,8 +28,6 @@
       ],
     },
   ];
-
-  type Preferences = Record<string, string>;
 
   let dirtyPrefs: Preferences = {};
 

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -1,9 +1,29 @@
 <script lang="ts">
   import Button from '../components/Button.svelte';
   import Layout from '../components/Layout.svelte';
+  import Textbox from '../components/Textbox.svelte';
   import IconButton from '../components/IconButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
   import { theme, themeOptions } from '../lib/theme';
+
+  let typographyPrefs = [
+    {
+      variable: 'main-font-size',
+      value: '16px',
+    },
+    {
+      variable: 'log-font-size',
+      value: '15px',
+    },
+    {
+      variable: 'ligatures-logs',
+      value: 'none',
+    },
+    {
+      variable: 'ligatures-code',
+      value: 'none',
+    },
+  ];
 </script>
 
 <Layout>
@@ -16,7 +36,7 @@
       />
     </div>
     <div>
-      <div>
+      <div class="group">
         <div class="group-header">
           <h2>Theme &amp; GUI</h2>
         </div>
@@ -31,11 +51,35 @@
           {/each}
         </div>
       </div>
+
+      <div class="group">
+        <div class="group-header">
+          <h2>Typography</h2>
+        </div>
+        {#each typographyPrefs as pref}
+          <div class="input-row">
+            <code>{pref.variable}</code>
+            <Textbox bind:value={pref.value} --input-width="100%" />
+          </div>
+        {/each}
+      </div>
     </div>
   </CenterFormPanel>
 </Layout>
 
 <style>
+  .input-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+
+  .group:not(:last-child) {
+    margin-bottom: 40px;
+  }
+
   .group-header {
     display: flex;
     justify-content: space-between;

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import Button from '../components/Button.svelte';
   import Layout from '../components/Layout.svelte';
-  import Textbox from '../components/Textbox.svelte';
   import IconButton from '../components/IconButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
   import { theme, themeOptions } from '../lib/theme';
   import type { Preferences } from '../lib/preferences';
   import { preferences } from '../lib/preferences';
   import { onMount } from 'svelte';
+  import InputQuantity from '../components/form/InputQuantity.svelte';
+  import InputSelection from '../components/form/InputSelection.svelte';
 
   type PreferenceName = keyof Preferences;
 
@@ -63,6 +64,8 @@
   onMount(() => {
     dirtyPrefs = $preferences;
   });
+
+  let testBindQVal = '215px';
 </script>
 
 <Layout>
@@ -105,15 +108,30 @@
           {#each group.preferences as preference}
             <div class="input-row">
               <code>{preference.name}</code>
-              <Textbox
-                bind:value={dirtyPrefs[preference.name]}
-                on:input={() => preferences.apply({ ...dirtyPrefs })}
-                --input-width="100%"
-              />
+              {#if preference.type === 'quantity'}
+                <InputQuantity
+                  bind:value={dirtyPrefs[preference.name]}
+                  on:input={() => preferences.apply({ ...dirtyPrefs })}
+                  unitOptions={preference.units}
+                />
+              {:else if preference.type === 'select'}
+                <InputSelection
+                  bind:value={dirtyPrefs[preference.name]}
+                  on:input={() => preferences.apply({ ...dirtyPrefs })}
+                  options={preference.options}
+                />
+              {/if}
             </div>
           {/each}
         </div>
       {/each}
+    </div>
+    <hr />
+    <div>
+      <p>
+        testBindQVal = {testBindQVal}
+      </p>
+      <InputQuantity bind:value={testBindQVal} unitOptions={['px', 'rem']} />
     </div>
   </CenterFormPanel>
 </Layout>

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -9,21 +9,43 @@
   import { preferences } from '../lib/preferences';
   import { onMount } from 'svelte';
 
-  let prefGroups = [
+  type PreferenceName = keyof Preferences;
+
+  interface PreferenceGroup {
+    title: string;
+    preferences: PreferenceGroupEntry[];
+  }
+
+  interface PreferenceGroupEntry {
+    name: PreferenceName;
+    type: 'quantity' | 'select';
+    units?: string[];
+    options?: string[];
+  }
+
+  const groups: PreferenceGroup[] = [
     {
       title: 'Typography',
-      prefs: [
+      preferences: [
         {
           name: 'main-font-size',
+          type: 'quantity',
+          units: ['px', 'em', 'rem', 'ex', '%'],
         },
         {
           name: 'log-font-size',
+          type: 'quantity',
+          units: ['px', 'em', 'rem', 'ex', '%'],
         },
         {
           name: 'ligatures-logs',
+          type: 'select',
+          options: ['none', 'normal', 'common-ligatures'],
         },
         {
           name: 'ligatures-code',
+          type: 'select',
+          options: ['none', 'normal', 'common-ligatures'],
         },
       ],
     },
@@ -54,7 +76,7 @@
     <div>
       <div class="group">
         <div class="group-header">
-          <h2>Theme &amp; GUI</h2>
+          <h2>{'Theme & GUI'}</h2>
         </div>
         <div class="button-row">
           {#each themeOptions as option}
@@ -68,16 +90,16 @@
         </div>
       </div>
 
-      {#each prefGroups as group}
+      {#each groups as group}
         <div class="group">
           <div class="group-header">
             <h2>{group.title}</h2>
           </div>
-          {#each group.prefs as pref}
+          {#each group.preferences as preference}
             <div class="input-row">
-              <code>{pref.name}</code>
+              <code>{preference.name}</code>
               <Textbox
-                bind:value={dirtyPrefs[pref.name]}
+                bind:value={dirtyPrefs[preference.name]}
                 on:input={() => preferences.apply({ ...dirtyPrefs })}
                 --input-width="100%"
               />

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -11,16 +11,23 @@
 
   type PreferenceName = keyof Preferences;
 
-  interface PreferenceGroup {
-    title: string;
-    preferences: PreferenceGroupEntry[];
+  interface QuantityPreference {
+    name: PreferenceName;
+    type: 'quantity';
+    units?: string[];
   }
 
-  interface PreferenceGroupEntry {
+  interface SelectPreference {
     name: PreferenceName;
-    type: 'quantity' | 'select';
-    units?: string[];
-    options?: string[];
+    type: 'select';
+    options: string[];
+  }
+
+  type Preference = QuantityPreference | SelectPreference;
+
+  interface PreferenceGroup {
+    title: string;
+    preferences: Preference[];
   }
 
   const groups: PreferenceGroup[] = [

--- a/gui/src/pages/Preferences.svelte
+++ b/gui/src/pages/Preferences.svelte
@@ -5,25 +5,36 @@
   import IconButton from '../components/IconButton.svelte';
   import CenterFormPanel from '../components/form/CenterFormPanel.svelte';
   import { theme, themeOptions } from '../lib/theme';
+  import { preferences } from '../lib/preferences';
+  import { onMount } from 'svelte';
 
-  let typographyPrefs = [
+  let prefGroups = [
     {
-      variable: 'main-font-size',
-      value: '16px',
-    },
-    {
-      variable: 'log-font-size',
-      value: '15px',
-    },
-    {
-      variable: 'ligatures-logs',
-      value: 'none',
-    },
-    {
-      variable: 'ligatures-code',
-      value: 'none',
+      title: 'Typography',
+      prefs: [
+        {
+          name: 'main-font-size',
+        },
+        {
+          name: 'log-font-size',
+        },
+        {
+          name: 'ligatures-logs',
+        },
+        {
+          name: 'ligatures-code',
+        },
+      ],
     },
   ];
+
+  type Preferences = Record<string, string>;
+
+  let dirtyPrefs: Preferences = {};
+
+  onMount(() => {
+    dirtyPrefs = $preferences;
+  });
 </script>
 
 <Layout>
@@ -32,7 +43,13 @@
       <IconButton
         glyph="Reset"
         tooltip="Reset to defaults"
-        on:click={() => theme.apply('auto')}
+        on:click={() => {
+          theme.apply('auto');
+          preferences.reset();
+          setTimeout(() => {
+            dirtyPrefs = $preferences;
+          }, 50);
+        }}
       />
     </div>
     <div>
@@ -52,17 +69,23 @@
         </div>
       </div>
 
-      <div class="group">
-        <div class="group-header">
-          <h2>Typography</h2>
-        </div>
-        {#each typographyPrefs as pref}
-          <div class="input-row">
-            <code>{pref.variable}</code>
-            <Textbox bind:value={pref.value} --input-width="100%" />
+      {#each prefGroups as group}
+        <div class="group">
+          <div class="group-header">
+            <h2>{group.title}</h2>
           </div>
-        {/each}
-      </div>
+          {#each group.prefs as pref}
+            <div class="input-row">
+              <code>{pref.name}</code>
+              <Textbox
+                bind:value={dirtyPrefs[pref.name]}
+                on:input={() => preferences.apply({ ...dirtyPrefs })}
+                --input-width="100%"
+              />
+            </div>
+          {/each}
+        </div>
+      {/each}
     </div>
   </CenterFormPanel>
 </Layout>


### PR DESCRIPTION
Per user request, adds preferences to modify font-size for logs and the rest of the UI, as well as ligatures settings.

- [x] Control CSS with pref variables
- [x] Bind Preferences page controls with `localStorage`
- [x] Use dropdown lists and number inputs for unit-based sizing controls and list selection ligature controls
- [ ] Fix unit input loading bug (works fine isolated, loads empty from preferences object)

![image](https://user-images.githubusercontent.com/51100181/138618165-452fb3e0-e06f-42f0-b947-d0efa340f055.png)
![image](https://user-images.githubusercontent.com/51100181/138618172-92e22562-abbe-40f8-beb8-21f2769b28c5.png)
