### PR TITLE
Don't prevent default on button press

### DIFF
--- a/gui/src/components/Button.svelte
+++ b/gui/src/components/Button.svelte
@@ -37,7 +37,7 @@
   class:small
   class:danger
   class:inset
-  on:click|preventDefault={handleClick}
+  on:click={handleClick}
   {type}
 >
   <slot />


### PR DESCRIPTION
Prevent default breaks the submit button. I don't see any particular reason to prevent the default action for a button anyway.