### PR TITLE
Fix shortcut triggering

### DIFF
--- a/gui/src/components/Layout.svelte
+++ b/gui/src/components/Layout.svelte
@@ -14,7 +14,11 @@
 <main>
   <nav>
     <header>
-      <NavbarButton title="Home" href="#/" shortcutParams={{ code: 'KeyH' }}>
+      <NavbarButton
+        title="Home"
+        href="#/"
+        shortcutParams={{ code: 'KeyH', alt: true }}
+      >
         {#if import.meta.env.MODE === 'development'}
           <img src="/deref-rounded-icon-dev.png" alt="Deref" height="24px" />
         {:else}
@@ -29,7 +33,7 @@
       <NavbarButton
         title="Preferences"
         href="#/preferences"
-        shortcutParams={{ code: 'KeyP' }}
+        shortcutParams={{ code: 'KeyP', alt: true }}
       >
         <Icon glyph="Preferences" />
       </NavbarButton>


### PR DESCRIPTION
This fixes the issue whereby if you tried to type the letter "h" or "p" into an input field you would be navigated away to a different page.

It's not safe to have shortcuts that have no associated modifier key since the handlers will otherwise run on every keypress indiscriminately.