### PR TITLE
Simplify button dispatch

### DIFF
--- a/gui/src/components/Button.svelte
+++ b/gui/src/components/Button.svelte
@@ -15,6 +15,7 @@
 
   const handleClick = (e: MouseEvent) => {
     if (href) {
+      e.preventDefault();
       if (!absoluteUrl.test(href)) {
         // Handle internal routes.
         router.push(href);


### PR DESCRIPTION
This should prevent any possibility of dispatching the default event twice.