### PR TITLE
manifest rewrite (starting with expand)

### DIFF
--- a/internal/cli/manifest_expand.go
+++ b/internal/cli/manifest_expand.go
@@ -3,7 +3,8 @@ package cli
 import (
 	"os"
 
-	"github.com/kr/pretty"
+	"github.com/deref/exo/internal/manifest/exohcl"
+	"github.com/deref/exo/internal/manifest/exohcl/hclgen"
 	"github.com/spf13/cobra"
 )
 
@@ -17,12 +18,13 @@ var manifestExpandCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := newContext()
-		res, err := loadManifest(ctx, os.Stderr, args[0])
+		m, err := loadManifest(ctx, os.Stderr, args[0])
 		if err != nil {
 			return err
 		}
-		// XXX Print expanded version of manifest as HCL, not internal data structures.
-		_, _ = pretty.Println(res)
+
+		expanded := exohcl.RewriteManifest(&exohcl.Expand{Context: ctx}, m)
+		hclgen.WriteTo(os.Stdout, expanded)
 		return nil
 	},
 }

--- a/internal/cli/manifest_format.go
+++ b/internal/cli/manifest_format.go
@@ -21,7 +21,7 @@ var manifestFormatCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		_, err = hclgen.WriteTo(os.Stdout, m.File)
+		_, err = hclgen.WriteTo(os.Stdout, hclgen.FileFromStructure(m.File))
 		return err
 	},
 }

--- a/internal/manifest/compose/import.go
+++ b/internal/manifest/compose/import.go
@@ -179,7 +179,7 @@ func (imp *Importer) Import(ctx *exohcl.AnalysisContext, bs []byte) *hcl.File {
 			if condition.Value != "service_started" {
 				var subject *hcl.Range
 				ctx.AppendDiags(exohcl.NewUnsupportedFeatureWarning(
-					fmt.Sprintf("service condition %q", dependency.Service),
+					fmt.Sprintf("service condition %q", dependency.Condition.Value),
 					"only service_started is currently supported",
 					subject,
 				))

--- a/internal/manifest/compose/import_test.go
+++ b/internal/manifest/compose/import_test.go
@@ -130,7 +130,7 @@ components {
 			if !hclgen.FileEquiv(expected, &hcl.File{Body: actual.Body}) {
 				t.Errorf("hcl files inequivalent. expected:\n%s\nactual:\n%s",
 					testCase.Expected,
-					string(hclgen.FormatFile(actual)))
+					string(hclgen.FormatFile(hclgen.FileFromStructure(actual))))
 			}
 		})
 	}

--- a/internal/manifest/exohcl/expand.go
+++ b/internal/manifest/exohcl/expand.go
@@ -1,0 +1,16 @@
+package exohcl
+
+import (
+	"context"
+
+	"github.com/deref/exo/internal/manifest/exohcl/hclgen"
+)
+
+type Expand struct {
+	context.Context
+	RewriteBase
+}
+
+func (_ Expand) RewriteComponent(re Rewrite, c *Component) *hclgen.Block {
+	return hclgen.BlockFromSyntax(c.Expansion)
+}

--- a/internal/manifest/exohcl/hclgen/ast.go
+++ b/internal/manifest/exohcl/hclgen/ast.go
@@ -10,6 +10,16 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
+type File struct {
+	Body *Body
+}
+
+func FileFromStructure(file *hcl.File) *File {
+	return &File{
+		Body: BodyFromStructure(file.Body),
+	}
+}
+
 type Block struct {
 	Type   string
 	Labels []string
@@ -21,32 +31,51 @@ type Block struct {
 	CloseBraceRange hcl.Range
 }
 
-func blocksFromSyntax(blocks []*hclsyntax.Block) []*Block {
+func BlocksFromStructure(blocks []*hcl.Block) []*Block {
 	res := make([]*Block, len(blocks))
 	for i, block := range blocks {
-		res[i] = blockFromSyntax(block)
+		res[i] = BlockFromStructure(block)
 	}
 	return res
 }
 
-func blockFromSyntax(in *hclsyntax.Block) *Block {
-	return &Block{
-		Type:   in.Type,
-		Labels: in.Labels,
-		Body:   bodyFromSyntax(in.Body),
+func BlocksFromSyntax(blocks []*hclsyntax.Block) []*Block {
+	res := make([]*Block, len(blocks))
+	for i, block := range blocks {
+		res[i] = BlockFromSyntax(block)
+	}
+	return res
+}
 
-		TypeRange:       in.TypeRange,
-		LabelRanges:     in.LabelRanges,
-		OpenBraceRange:  in.OpenBraceRange,
-		CloseBraceRange: in.CloseBraceRange,
+func BlockFromStructure(block *hcl.Block) *Block {
+	return &Block{
+		Type:   block.Type,
+		Labels: block.Labels,
+		Body:   BodyFromStructure(block.Body),
+
+		TypeRange:   block.TypeRange,
+		LabelRanges: block.LabelRanges,
 	}
 }
 
-func (b *Block) syntaxBlock() *hclsyntax.Block {
+func BlockFromSyntax(block *hclsyntax.Block) *Block {
+	return &Block{
+		Type:   block.Type,
+		Labels: block.Labels,
+		Body:   BodyFromSyntax(block.Body),
+
+		TypeRange:       block.TypeRange,
+		LabelRanges:     block.LabelRanges,
+		OpenBraceRange:  block.OpenBraceRange,
+		CloseBraceRange: block.CloseBraceRange,
+	}
+}
+
+func (b *Block) SyntaxBlock() *hclsyntax.Block {
 	return &hclsyntax.Block{
 		Type:   b.Type,
 		Labels: b.Labels,
-		Body:   b.Body.syntaxBody(),
+		Body:   b.Body.SyntaxBody(),
 
 		TypeRange:       b.TypeRange,
 		LabelRanges:     b.LabelRanges,
@@ -63,10 +92,10 @@ type Body struct {
 	EndRange hcl.Range
 }
 
-func bodyFromStructure(body hcl.Body) *Body {
+func BodyFromStructure(body hcl.Body) *Body {
 	switch body := body.(type) {
 	case *hclsyntax.Body:
-		return bodyFromSyntax(body)
+		return BodyFromSyntax(body)
 	case *Body:
 		return body
 	default:
@@ -74,17 +103,17 @@ func bodyFromStructure(body hcl.Body) *Body {
 	}
 }
 
-func bodyFromSyntax(body *hclsyntax.Body) *Body {
+func BodyFromSyntax(body *hclsyntax.Body) *Body {
 	return &Body{
-		Attributes: attributesFromSytnax(body.Attributes),
-		Blocks:     blocksFromSyntax(body.Blocks),
+		Attributes: AttributesFromSytnax(body.Attributes),
+		Blocks:     BlocksFromSyntax(body.Blocks),
 
 		SrcRange: body.SrcRange,
 		EndRange: body.EndRange,
 	}
 }
 
-func (b *Body) syntaxAttributes() hclsyntax.Attributes {
+func (b *Body) SyntaxAttributes() hclsyntax.Attributes {
 	res := make(hclsyntax.Attributes)
 	for _, attr := range b.Attributes {
 		res[attr.Name] = attr
@@ -92,44 +121,65 @@ func (b *Body) syntaxAttributes() hclsyntax.Attributes {
 	return res
 }
 
-func (b *Body) syntaxBlocks() []*hclsyntax.Block {
+func (b *Body) SyntaxBlocks() []*hclsyntax.Block {
 	res := make([]*hclsyntax.Block, len(b.Blocks))
 	for i, block := range b.Blocks {
-		res[i] = block.syntaxBlock()
+		res[i] = block.SyntaxBlock()
 	}
 	return res
 }
 
-func (b *Body) syntaxBody() *hclsyntax.Body {
+func (b *Body) SyntaxBody() *hclsyntax.Body {
 	return &hclsyntax.Body{
-		Attributes: b.syntaxAttributes(),
-		Blocks:     b.syntaxBlocks(),
+		Attributes: b.SyntaxAttributes(),
+		Blocks:     b.SyntaxBlocks(),
 		SrcRange:   b.SrcRange,
 		EndRange:   b.EndRange,
 	}
 }
 
 func (b *Body) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
-	return b.syntaxBody().Content(schema)
+	return b.SyntaxBody().Content(schema)
 }
 
 func (b *Body) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
-	return b.syntaxBody().PartialContent(schema)
+	return b.SyntaxBody().PartialContent(schema)
 }
 
 func (b *Body) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
-	return b.syntaxBody().JustAttributes()
+	return b.SyntaxBody().JustAttributes()
 }
 
 func (b *Body) MissingItemRange() hcl.Range {
-	return b.syntaxBody().MissingItemRange()
+	return b.SyntaxBody().MissingItemRange()
 }
 
 type Attributes []*Attribute
 
 type Attribute = hclsyntax.Attribute
 
-func attributesFromSytnax(attributes hclsyntax.Attributes) Attributes {
+type Expression = hclsyntax.Expression
+
+func AttributesFromStructure(attributes hcl.Attributes) Attributes {
+	res := make(Attributes, 0, len(attributes))
+	for _, attribute := range attributes {
+		res = append(res, AttributeFromStructure(attribute))
+	}
+	sort.Sort(res)
+	return res
+}
+
+func AttributeFromStructure(attribute *hcl.Attribute) *Attribute {
+	return &hclsyntax.Attribute{
+		Name:        attribute.Name,
+		Expr:        ExpressionFromStructure(attribute.Expr),
+		SrcRange:    attribute.Range,
+		NameRange:   attribute.NameRange,
+		EqualsRange: attribute.NameRange,
+	}
+}
+
+func AttributesFromSytnax(attributes hclsyntax.Attributes) Attributes {
 	res := make(Attributes, 0, len(attributes))
 	for _, attribute := range attributes {
 		res = append(res, attribute)
@@ -149,4 +199,8 @@ func (a Attributes) Less(i, j int) bool {
 		return true
 	}
 	return lhs.Name < rhs.Name
+}
+
+func ExpressionFromStructure(expr hcl.Expression) Expression {
+	return expr.(hclsyntax.Expression)
 }

--- a/internal/manifest/exohcl/hclgen/equiv.go
+++ b/internal/manifest/exohcl/hclgen/equiv.go
@@ -10,8 +10,8 @@ func FileEquiv(a, b *hcl.File) bool {
 }
 
 func BodyEquiv(a, b hcl.Body) bool {
-	synA := bodyFromStructure(a).syntaxBody()
-	synB := bodyFromStructure(b).syntaxBody()
+	synA := BodyFromStructure(a).SyntaxBody()
+	synB := BodyFromStructure(b).SyntaxBody()
 	return AttributesEquiv(synA.Attributes, synB.Attributes) && BlocksEquiv(synA.Blocks, synB.Blocks)
 }
 

--- a/internal/manifest/exohcl/hclgen/generate.go
+++ b/internal/manifest/exohcl/hclgen/generate.go
@@ -12,13 +12,13 @@ import (
 // Writes an HCL file AST to w. Note that syntax trivia (comments and
 // whitespace) are not preserved, and so this function is only appropriate for
 // conversion/generation use cases.
-func WriteTo(w io.Writer, f *hcl.File) (int64, error) {
+func WriteTo(w io.Writer, f *File) (int64, error) {
 	out := hclwrite.NewEmptyFile()
 	genFileTo(out, f)
 	return out.WriteTo(w)
 }
 
-func FormatFile(f *hcl.File) []byte {
+func FormatFile(f *File) []byte {
 	var buf bytes.Buffer
 	_, err := WriteTo(&buf, f)
 	if err != nil {
@@ -40,12 +40,12 @@ func FormatExpression(x hclsyntax.Expression) []byte {
 	return f.Bytes()
 }
 
-func genFileTo(out *hclwrite.File, in *hcl.File) {
+func genFileTo(out *hclwrite.File, in *File) {
 	genBodyTo(out.Body(), in.Body)
 }
 
 func genBodyTo(out *hclwrite.Body, in hcl.Body) {
-	body := bodyFromStructure(in)
+	body := BodyFromStructure(in)
 	for _, attr := range body.Attributes {
 		out.SetAttributeRaw(attr.Name, TokensForExpression(attr.Expr))
 	}

--- a/internal/manifest/exohcl/hclgen/generate_test.go
+++ b/internal/manifest/exohcl/hclgen/generate_test.go
@@ -34,9 +34,8 @@ func TestGenerate(t *testing.T) {
 		if !assert.False(t, diags.HasErrors()) {
 			continue
 		}
-		bs := hclgen.FormatFile(&hcl.File{
-			Body:  f.Body.(*hclsyntax.Body),
-			Bytes: f.Bytes,
+		bs := hclgen.FormatFile(&hclgen.File{
+			Body: hclgen.BodyFromStructure(f.Body),
 		})
 		formatted := string(hclwrite.Format([]byte(src)))
 

--- a/internal/manifest/exohcl/rewrite.go
+++ b/internal/manifest/exohcl/rewrite.go
@@ -1,0 +1,105 @@
+package exohcl
+
+import (
+	"context"
+
+	"github.com/deref/exo/internal/manifest/exohcl/hclgen"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Rewrite interface {
+	context.Context
+	RewriteManifest(Rewrite, *Manifest) *hclgen.File
+	RewriteEnvironment(Rewrite, *Environment) *hclgen.Block
+	RewriteComponents(Rewrite, *ComponentSet) *hclgen.Block
+	RewriteComponent(Rewrite, *Component) *hclgen.Block
+}
+
+func RewriteManifest(re Rewrite, m *Manifest) *hclgen.File {
+	return re.RewriteManifest(re, m)
+}
+
+func RewriteEnvironment(re Rewrite, env *Environment) *hclgen.Block {
+	return re.RewriteEnvironment(re, env)
+}
+
+func RewriteComponents(re Rewrite, cs *ComponentSet) *hclgen.Block {
+	return re.RewriteComponents(re, cs)
+}
+
+func RewriteComponent(re Rewrite, c *Component) *hclgen.Block {
+	return re.RewriteComponent(re, c)
+}
+
+type RewriteBase struct{}
+
+func (_ RewriteBase) RewriteManifest(re Rewrite, m *Manifest) *hclgen.File {
+	skip := make(map[*hcl.Block]bool)
+	blocks := make([]*hclgen.Block, 0, len(m.Content.Blocks))
+
+	env := NewEnvironment(m)
+	if diags := Analyze(re, env); diags.HasErrors() {
+		env = nil
+	} else {
+		for _, block := range env.Blocks {
+			skip[block] = true
+		}
+		block := RewriteEnvironment(re, env)
+		if block != nil {
+			blocks = append(blocks, block)
+		}
+	}
+
+	cs := NewComponentSet(m)
+	if diags := Analyze(re, cs); diags.HasErrors() {
+		cs = nil
+	} else {
+		for _, block := range cs.Blocks {
+			skip[block] = true
+		}
+		block := RewriteComponents(re, cs)
+		if block != nil {
+			blocks = append(blocks, block)
+		}
+	}
+
+	for _, block := range m.Content.Blocks {
+		if skip[block] {
+			continue
+		}
+		blocks = append(blocks, hclgen.BlockFromStructure(block))
+	}
+
+	body := &hclgen.Body{
+		Attributes: hclgen.AttributesFromStructure(m.Content.Attributes),
+		Blocks:     blocks,
+	}
+	return &hclgen.File{
+		Body: body,
+	}
+}
+
+func (_ RewriteBase) RewriteEnvironment(re Rewrite, env *Environment) *hclgen.Block {
+	if len(env.Blocks) == 0 {
+		return nil
+	}
+	// TODO: Handle richer environments.
+	return hclgen.BlockFromStructure(env.Blocks[0])
+}
+
+func (_ RewriteBase) RewriteComponents(re Rewrite, cs *ComponentSet) *hclgen.Block {
+	blocks := make([]*hclgen.Block, len(cs.Components))
+	for i, c := range cs.Components {
+		blocks[i] = RewriteComponent(re, c)
+	}
+	return &hclgen.Block{
+		Type: "components",
+		Body: &hclgen.Body{
+			Blocks: blocks,
+		},
+	}
+}
+
+func (_ RewriteBase) RewriteComponent(re Rewrite, c *Component) *hclgen.Block {
+	return hclgen.BlockFromSyntax(c.Source)
+}


### PR DESCRIPTION
Basic visitor for rewriting manifests. First implementation of the visitor interface is the Expand rewrite, to eliminate shorthands; mostly exists for testing/debugging.