### PR TITLE
Height-capped directory browser with scrolling for long lists

### DIFF
--- a/gui/src/components/DirectoryBrowser.svelte
+++ b/gui/src/components/DirectoryBrowser.svelte
@@ -72,20 +72,15 @@
 
   .directories {
     margin: 12px 0;
+    max-height: 20rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-radius: 5px;
+    box-shadow: var(--button-shadow);
   }
 
   .directories button {
     border-radius: 0;
-  }
-
-  .directories button:first-of-type {
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-  }
-
-  .directories button:last-of-type {
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
   }
 
   button {
@@ -100,8 +95,11 @@
     grid-template-columns: max-content 2fr;
     align-items: center;
     gap: 12px;
-    margin-top: 1px;
     outline: none;
+  }
+
+  button:not(:last-child) {
+    margin-bottom: 1px;
   }
 
   button:disabled {
@@ -121,5 +119,11 @@
   button:focus,
   button:focus-within {
     box-shadow: var(--shadow-focus) !important;
+  }
+
+  .directories button:focus,
+  .directories button:focus-within {
+    margin: 1px 2px;
+    padding: 5px 8px;
   }
 </style>


### PR DESCRIPTION
This is a working but not ideally styled implementation of scrolling height-capped directory browser, addressing #507 

Could also use this branch to make additional directory browser improvements addressing issues as noted by @brandonbloom earlier today - e.g. symlinks not showing up, and some directories on MacOS not being considered directories by the library.

Another improvement could be to the way the new project directory name input + full path display works. Inline edit should be possible and a UX improvement.