### PR TITLE
New internals

### DIFF
--- a/internal/providers/core/resource.go
+++ b/internal/providers/core/resource.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+type ResourceContext interface {
+	context.Context
+
+	NewController(ctx context.Context, typ string) (ResourceController, error)
+	GetResourceType(ctx context.Context, iri string) (typ string, err error)
+
+	BeginCreate(ctx context.Context, typ string, spec string) (opID string, err error)
+	EndCreate(ctx context.Context, opID string, iri string, err error) error
+
+	BeginUpdate(ctx context.Context, iri string, patch string) (opID string, err error)
+	EndUpdate(ctx context.Context, opID string, err error) error
+
+	BeginDelete(ctx context.Context, iri string) (opID string, err error)
+	EndDelete(ctx context.Context, opID string, err error) error
+}
+
+type Resource struct {
+	ctrl ResourceController
+	iri  string
+}
+
+type ResourceController interface {
+	Create(ctx context.Context, spec string) (iri string, err error)
+	LoadIRI(iri string) error
+	Exists(ctx context.Context) (bool, error)
+	Update(ctx context.Context, patch string) error
+	Delete(ctx context.Context) error
+}
+
+func CreateResource(ctx ResourceContext, typ string, spec string) (res *Resource, err error) {
+	ctrl, err := ctx.NewController(ctx, typ)
+	if err != nil {
+		return nil, fmt.Errorf("creating %q controller: %w", typ, err)
+	}
+	res = &Resource{
+		ctrl: ctrl,
+	}
+
+	opID, beginErr := ctx.BeginCreate(ctx, typ, spec)
+	if beginErr != nil {
+		return nil, fmt.Errorf("beginning: %w", beginErr)
+	}
+	defer func() {
+		if endErr := ctx.EndCreate(ctx, opID, res.iri, err); endErr != nil {
+			if err == nil {
+				err = fmt.Errorf("ending: %w", endErr)
+			}
+		}
+	}()
+
+	res.iri, err = res.ctrl.Create(ctx, spec)
+	return
+}
+
+func GetResource(ctx ResourceContext, iri string) (*Resource, error) {
+	typ, err := ctx.GetResourceType(ctx, iri)
+	if err != nil {
+		return nil, fmt.Errorf("getting resource type: %w", err)
+	}
+
+	ctrl, err := ctx.NewController(ctx, typ)
+	if err != nil {
+		return nil, fmt.Errorf("creating %q controller: %w", typ, err)
+	}
+
+	res := &Resource{
+		iri:  iri,
+		ctrl: ctrl,
+	}
+	return res, nil
+}
+
+func (res *Resource) Update(ctx ResourceContext, spec string) (err error) {
+	opID, beginErr := ctx.BeginUpdate(ctx, res.iri, spec)
+	if beginErr != nil {
+		return fmt.Errorf("beginning: %w", beginErr)
+	}
+	defer func() {
+		if endErr := ctx.EndUpdate(ctx, opID, err); endErr != nil {
+			if err == nil {
+				err = fmt.Errorf("ending: %w", endErr)
+			}
+		}
+	}()
+
+	err = res.ctrl.Update(ctx, spec)
+	return
+}
+
+func (res *Resource) Delete(ctx ResourceContext) (err error) {
+	opID, beginErr := ctx.BeginDelete(ctx, res.iri)
+	if beginErr != nil {
+		return fmt.Errorf("beginning: %w", beginErr)
+	}
+	defer func() {
+		if endErr := ctx.EndDelete(ctx, opID, err); endErr != nil {
+			if err == nil {
+				err = fmt.Errorf("ending: %w", endErr)
+			}
+		}
+	}()
+
+	err = res.ctrl.Delete(ctx)
+	return
+}

--- a/internal/providers/unix/process/resource.go
+++ b/internal/providers/unix/process/resource.go
@@ -68,8 +68,8 @@ func (res *Resource) Create(ctx context.Context, spec string) (iri string, err e
 		Dir:   start.Directory,
 		Env:   env,
 		Files: files,
-		Sys:   &syscall.SysProcAttr{
-			// XXX stuff here.
+		Sys: &syscall.SysProcAttr{
+			Setsid: true,
 		},
 	})
 	if err != nil {

--- a/internal/providers/unix/process/resource.go
+++ b/internal/providers/unix/process/resource.go
@@ -1,0 +1,133 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/deref/exo/internal/util/jsonutil"
+	"github.com/deref/exo/internal/util/osutil"
+)
+
+type Resource struct {
+	Pid int
+}
+
+type Start struct {
+	// Absolute path to working directory.
+	Directory string `json:"directory"`
+	// Absolute path to program to execute.
+	Program string `json:"program"`
+	// Command line arguments.
+	Arguments []string `json:"arguments"`
+	// Complete environment given to the process.
+	Environment map[string]string `json:"environment"`
+	// File paths to attach. First three are generally stdin, stdout, and stderr.
+	Files []OpenFile `json:"files"`
+}
+
+type OpenFile struct {
+	Path string `json:"path"`
+	Flag int    `json:"flag"`
+	Perm int    `json:"perm"`
+}
+
+func (res *Resource) Create(ctx context.Context, spec string) (iri string, err error) {
+	var start Start
+	if err := jsonutil.UnmarshalString(spec, &start); err != nil {
+		return "", fmt.Errorf("unmarshalling spec: %w", err)
+	}
+
+	argv := append([]string{start.Program}, start.Arguments...)
+
+	envKeys := make([]string, 0, len(start.Environment))
+	for k := range start.Environment {
+		envKeys = append(envKeys, k)
+	}
+	sort.Strings(envKeys)
+	env := make([]string, len(start.Environment))
+	for i, k := range envKeys {
+		env[i] = fmt.Sprintf("%s=%s", k, start.Environment[k])
+	}
+
+	files := make([]*os.File, len(start.Files))
+	for fd, startFile := range start.Files {
+		f, err := os.OpenFile(startFile.Path, startFile.Flag, os.FileMode(startFile.Perm))
+		if err != nil {
+			return "", fmt.Errorf("opening fd %d: %w", fd, err)
+		}
+		files[fd] = f
+	}
+
+	proc, err := os.StartProcess(argv[0], argv, &os.ProcAttr{
+		Dir:   start.Directory,
+		Env:   env,
+		Files: files,
+		Sys:   &syscall.SysProcAttr{
+			// XXX stuff here.
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	pid := proc.Pid
+	iri = MakeIRI(pid)
+	return iri, nil
+}
+
+func (res *Resource) LoadIRI(ctx context.Context, iri string) error {
+	pid, err := ParseIRI(iri)
+	if err != nil {
+		return fmt.Errorf("invalid process iri: %w", err)
+	}
+	res.Pid = pid
+	return nil
+}
+
+func MakeIRI(pid int) string {
+	return fmt.Sprintf("exo:unix:process/%d", pid) // XXX uri scheme ok here?
+}
+
+func ParseIRI(iri string) (pid int, err error) {
+	parts := strings.SplitN(iri, "/", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("expected /")
+	}
+	pid64, err := strconv.ParseInt(parts[1], 10, 32)
+	return int(pid64), err
+}
+
+func (res *Resource) Exists(ctx context.Context) (bool, error) {
+	return osutil.IsValidPid(res.Pid), nil
+}
+
+func (res *Resource) Update(ctx context.Context, patch string) error {
+	return errors.New("unsupported patch")
+}
+
+func (res *Resource) Delete(ctx context.Context) error {
+	if err := osutil.SignalGroup(res.Pid, os.Interrupt); err != nil {
+		return fmt.Errorf("interrupting: %w", err)
+	}
+
+	ok := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = osutil.KillGroup(res.Pid)
+		case <-ok:
+		}
+	}()
+
+	if _, err := osutil.WaitProcess(res.Pid); err != nil {
+		return fmt.Errorf("waiting: %w", err)
+	}
+	close(ok)
+	return nil
+}


### PR DESCRIPTION
extremely early, attempting to address or make possible to address numerous issues, including but not limited to:

- #324
- #290
- #21 
- #463 

The general ideas are as follows:

- Factor out "Stack" from "Workspace", specifically the bits in server/workspace.go that might have multiplicity N >= 0 relative to each workspace.
- Refactor "Component" in to physical and logical halves. The logical half will remain called "Component" and the physical half will be called a "Resource". Main distinction is that resources are expected to be external, have a globally unique IRI of some kind, and it is expected that their lifetime is shorter than a component and subject to external influences. Components may have zero or more resources. For example, a process-component will have start & stop, and each time it starts/stops, it will create/destroy a unix-process-resource.
- Keep a pending-operations log for CRUD operations on resources, so that if an operation fails, the user can debug/recover.
- Rework "apply" to use initialize/start/stop/dispose, causing components to create/delete resources, instead of create/delete-ing processes, containers, etc directly. (ie fix #290)
- Write a data migration codepath that takes the component state from above and moves it to some tables in sqlite instead of storing in the state.json file.
